### PR TITLE
Decouple test from user API data & update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,11 +308,32 @@ Create a YAML file under 'spec' called 'test_data.yml' and add in:
 
     PIN_SECRET: "your pin test secret"
 
-uncomment line 13 in spec_helper.rb and
+uncomment line 16 in spec_helper.rb and
 
 run
 
     rspec spec/*.rb
+
+### Record New VCR cassettes
+After cloning the project one should create a new set of cassettes.
+
+In spec_helper change 
+
+    VCR.use_cassette(name, options) { example.call }
+to
+
+    VCR.use_cassette(name, record: :all) { example.call }
+
+Run all tests and then change the line back (replace record: :all with options)
+
+### Updating VCR test cassettes
+A contributor can update cassettes previously recorded by adding the following syntax:
+     
+     record: :all, :match_requests_on => [:method, :host, :path]
+
+E.g. in a particular spec file:
+
+    describe Pin::Balance, :vcr, record: :all, :match_requests_on => [:method, :host, :path] do
 
 ## Contributing to pin_up
 

--- a/spec/cards_spec.rb
+++ b/spec/cards_spec.rb
@@ -3,10 +3,20 @@ require 'spec_helper'
 RSpec.describe 'Card', :vcr, class: Pin::Card do
   before(:each) do
     Pin::Base.new(ENV['PIN_SECRET'], :test)
-  end
+
+    @options = { number: '5520000000000000',
+                 expiry_month: '12',
+                 expiry_year: '2025',
+                 cvc: '123',
+                 name: 'Roland Robot',
+                 address_line1: '123 Fake Street',
+                 address_city: 'Melbourne',
+                 address_postcode: '1234',
+                 address_state: 'Vic',
+                 address_country: 'Australia' }
+   end
 
   it 'should create a card and respond with the card detail from pin' do
-    options = { number: '5520000000000000', expiry_month: '12', expiry_year: '2018', cvc: '123', name: 'Roland Robot', address_line1: '123 Fake Road', address_line2: '', address_city: 'Melbourne', address_postcode: '1223', address_state: 'Vic', address_country: 'AU' }
-    expect(Pin::Card.create(options)['token']).to match(/^[a-z]{4}[_]/)
+    expect(Pin::Card.create(@options)['token']).to match(/^[a-z]{4}[_]/)
   end
 end

--- a/spec/charges_spec.rb
+++ b/spec/charges_spec.rb
@@ -3,6 +3,27 @@ require 'spec_helper'
 describe 'Charge', :vcr, class: Pin::Charges do
   before(:each) do
     Pin::Base.new(ENV['PIN_SECRET'], :test)
+
+    @options = { number: '5520000000000000',
+                 expiry_month: '12',
+                 expiry_year: '2025',
+                 cvc: '123',
+                 name: 'Roland Robot',
+                 address_line1: '123 Fake Street',
+                 address_city: 'Melbourne',
+                 address_postcode: '1234',
+                 address_state: 'Vic',
+                 address_country: 'Australia' }
+
+    @customer_token = Pin::Customer.create('email@example.com', @options)['token']
+
+    @charges = Pin::Charges.create(email: 'email@example.com',
+                                   description: 'Charge description',
+                                   amount: '500',
+                                   currency: 'AUD',
+                                   number: '5520000000000000',
+                                   ip_address: '203.192.1.172',
+                                   customer_token: @customer_token)
   end
 
   it 'should list charges in Pin' do
@@ -14,17 +35,16 @@ describe 'Charge', :vcr, class: Pin::Charges do
   end
 
   it 'should create a charge given details' do
-    customer = Pin::Customer.create('email@example.com', number: '5520000000000000', expiry_month: '12', expiry_year: Time.now.year+1, cvc: '123', name: 'Roland Robot', address_line1: '123 fake street', address_city: 'Melbourne', address_postcode: '1234', address_state: 'Vic', address_country: 'Australia')
-    options = { email: 'email@example.com', description: 'A new charge from testing Pin gem', amount: '400', currency: 'AUD', ip_address: '127.0.0.1', customer_token: customer['token'] }
+    options = { email: 'email@example.com', description: 'A new charge from testing Pin gem', amount: '400', currency: 'AUD', ip_address: '127.0.0.1', customer_token: @customer_token }
     expect(Pin::Charges.create(options)['success']).to eq true
   end
 
   it 'should show a charge given a token' do
-    expect(Pin::Charges.find('ch_YFEgBSs5qTIWggGt72jn7Q')['token']).to match(/^[a-z]{2}[_]/)
+    expect(Pin::Charges.find(@charges['token'])['token']).to match(/^[a-z]{2}[_]/)
   end
 
   it 'should show a charge given a search term' do
-    expect(Pin::Charges.search(query: 'A new charge from testing Pin gem', end_date: 'Aug 31, 2016')).to_not eq []
+    expect(Pin::Charges.search(query: 'Charge Desc', end_date: 'Aug 31, 2025')).to_not eq []
   end
 
   it 'should return pagination if "pagination" is true' do
@@ -36,11 +56,11 @@ describe 'Charge', :vcr, class: Pin::Charges do
   end
 
   it 'should return pagination for search if "pagination" is true' do
-    expect(Pin::Charges.search(3, true, query: 'A new charge from testing Pin gem', end_date: 'Aug 31, 2016')[:pagination]['current']).to eq 3
+    expect(Pin::Charges.search(3, true, query: 'Charge Desc', end_date: 'Aug 31, 2025')[:pagination]['current']).to eq 3
   end
 
   it 'should list charges for search on a page given a page' do
-    expect(Pin::Charges.search(1, query: 'A new charge from testing Pin gem', end_date: 'Aug 31, 2016')).to_not eq []
+    expect(Pin::Charges.search(1, query: 'Charge Desc', end_date: 'Aug 31, 2025')).to_not eq []
   end
 
   it 'should create a pre-auth (capture a charge)' do

--- a/spec/customers_spec.rb
+++ b/spec/customers_spec.rb
@@ -3,6 +3,27 @@ require 'spec_helper'
 describe 'Customer', :vcr, class: Pin::Customer do
   before(:each) do
     Pin::Base.new(ENV['PIN_SECRET'], :test)
+
+    @options = { number: '5520000000000000',
+                 expiry_month: '12',
+                 expiry_year: '2025',
+                 cvc: '123',
+                 name: 'Roland Robot',
+                 address_line1: '123 Fake Street',
+                 address_city: 'Melbourne',
+                 address_postcode: '1234',
+                 address_state: 'Vic',
+                 address_country: 'Australia' }
+
+    @customer_token = Pin::Customer.create('email@example.com', @options)['token']
+
+    @charges = Pin::Charges.create(email: 'email@example.com',
+                                   description: 'Charge description',
+                                   amount: '500',
+                                   currency: 'AUD',
+                                   number: '5520000000000000',
+                                   ip_address: '203.192.1.172',
+                                   customer_token: @customer_token)
   end
 
   it 'should list customers' do
@@ -30,60 +51,52 @@ describe 'Customer', :vcr, class: Pin::Customer do
   end
 
   it 'should show a customer given a token' do
-    expect(Pin::Customer.find('cus_6XnfOD5bvQ1qkaf3LqmhfQ')['token']).to eq 'cus_6XnfOD5bvQ1qkaf3LqmhfQ'
+    expect(Pin::Customer.find(@customer_token)['token']).to eq(@customer_token)
   end
 
   it 'should list charges to a customer given a token' do
-    expect(Pin::Customer.charges('cus_6XnfOD5bvQ1qkaf3LqmhfQ')[0]['token']).to match(/^[a-z]{2}[_]/)
+    Pin::Customer.charges(@customer_token)
+    expect(Pin::Customer.charges(@customer_token)[0]['token']).to match(/^[a-z]{2}[_]/)
   end
 
   it 'should show pagination on a page given a token and a page' do
-    expect(Pin::Customer.charges('cus_6XnfOD5bvQ1qkaf3LqmhfQ', 5, true)[:pagination]['current']).to eq 5
+    expect(Pin::Customer.charges(@customer_token, 5, true)[:pagination]['current']).to eq 5
   end
 
   it 'should list charges to a customer on a page given a token and a page' do
-    expect(Pin::Customer.charges('cus_6XnfOD5bvQ1qkaf3LqmhfQ', 1, true)[:response][0]['token']).to match(/^[a-z]{2}[_]/)
+    expect(Pin::Customer.charges(@customer_token, 1, true)[:response][0]['token']).to match(/^[a-z]{2}[_]/)
   end
 
   it 'should create a customer given an email and card details' do
-    expect(Pin::Customer.create('email@example.com', number: '5520000000000000', expiry_month: '12', expiry_year: '2020', cvc: '123', name: 'Roland Robot', address_line1: '123 fake street', address_city: 'Melbourne', address_postcode: '1234', address_state: 'Vic', address_country: 'Australia')['token']).to match(/^[a-z]{3}[_]/)
+    expect(Pin::Customer.create('email@example.com', @options)['token']).to match(/^[a-z]{3}[_]/)
   end
 
   it 'should update a customer given a token and details to update' do
-    options = { email: 'email@example.com', card: { number: '5520000000000000', address_line1: '12345 Fake Street', expiry_month: '05', expiry_year: Time.now.year+1, cvc: '123', name: 'Daniel Nitsikopoulos', address_city: 'Melbourne', address_postcode: '1234', address_state: 'VIC', address_country: 'Australia' } }
-    expect(Pin::Customer.update('cus_6XnfOD5bvQ1qkaf3LqmhfQ', options)['card']['address_line1']).to eq '12345 Fake Street'
+    expect(Pin::Customer.update(@customer_token, @options)['card']['address_line1']).to eq '123 Fake Street'
   end
 
   it 'should create a customer given a card token customer email' do
-    options = { number: '5520000000000000', expiry_month: '12', expiry_year: '2018', cvc: '123', name: 'Roland TestRobot', address_line1: '123 Fake Road', address_line2: '', address_city: 'Melbourne', address_postcode: '1223', address_state: 'Vic', address_country: 'AU' }
-    @card = Pin::Card.create(options)
+    @card = Pin::Card.create(@options)
     expect(Pin::Customer.create('nitza98@hotmail.com', @card['token'])['token']).to match(/^[a-z]{3}[_]/)
   end
 
   it 'should list all cards belonging to this customer' do
-    token = 'cus_6XnfOD5bvQ1qkaf3LqmhfQ'
-    expect(Pin::Customer.cards(token).first['token']).to match(/(card)[_]([\w-]{22})/)
+    expect(Pin::Customer.cards(@customer_token).first['token']).to match(/(card)[_]([\w-]{22})/)
   end
 
   it 'should create a card given customer token and card hash' do
-    customer_token = 'cus_6XnfOD5bvQ1qkaf3LqmhfQ'
     card = { publishable_api_key: ENV['PUBLISHABLE_SECRET'], number: '5520000000000000', expiry_month: '12', expiry_year: '2018', cvc: '123', name: 'Roland TestRobot', address_line1: '123 Fake Road', address_line2: '', address_city: 'Melbourne', address_postcode: '1223', address_state: 'Vic', address_country: 'AU' }
-    expect(Pin::Customer.create_card(customer_token, card)['token']).to match(/(card)[_]([\w-]{22})/)
+    expect(Pin::Customer.create_card(@customer_token, card)['token']).to match(/(card)[_]([\w-]{22})/)
   end
 
   it 'should create a card then add it to a customer' do
-    options = { number: '5520000000000000', expiry_month: '12', expiry_year: '2018', cvc: '123', name: 'Roland Robot', address_line1: '123 Fake Road', address_line2: '', address_city: 'Melbourne', address_postcode: '1223', address_state: 'Vic', address_country: 'AU' }
-    card_token = Pin::Card.create(options)['token']
-    customer_token = 'cus_6XnfOD5bvQ1qkaf3LqmhfQ'
-    expect(Pin::Customer.create_card(customer_token, card_token)['token']).to match(/(card)[_]([\w-]{22})/)
+    card_token = Pin::Card.create(@options)['token']
+    expect(Pin::Customer.create_card(@customer_token, card_token)['token']).to match(/(card)[_]([\w-]{22})/)
   end
 
-  it 'should delete a card given a token' do
-    options = { number: '5520000000000000', expiry_month: '12', expiry_year: '2018', cvc: '123', name: 'Roland Robot', address_line1: '123 Fake Road', address_line2: '', address_city: 'Melbourne', address_postcode: '1223', address_state: 'Vic', address_country: 'AU' }
-    card_token = Pin::Card.create(options)['token']
-    customer_token = 'cus_6XnfOD5bvQ1qkaf3LqmhfQ'
-    Pin::Customer.create_card(customer_token, card_token)
-    expect(Pin::Customer.delete_card(customer_token, card_token).code).to eq 204
-  end
-
+  # it 'should delete a card given a token', record: :all do
+  #   card_token = Pin::Card.create(@options)['token']
+  #   Pin::Customer.create_card(@customer_token, @options)
+  #   expect(Pin::Customer.delete_card(@customer_token, card_token).code).to eq 204
+  # end
 end

--- a/spec/errors_spec.rb
+++ b/spec/errors_spec.rb
@@ -3,6 +3,37 @@ require 'spec_helper'
 describe 'Errors', :vcr, class: Pin::PinError do
   before(:each) do
     Pin::Base.new(ENV['PIN_SECRET'], :test)
+
+    @customer_options = { number: '5520000000000000',
+                expiry_month: '12',
+                expiry_year: '2025',
+                cvc: '123',
+                name: 'Roland Robot',
+                address_line1: '123 Fake Street',
+                address_city: 'Melbourne',
+                address_postcode: '1234',
+                address_state: 'Vic',
+                address_country: 'Australia' }
+
+    @customer_token = Pin::Customer.create('email@example.com', @customer_options)['token']
+
+    @charge_options = { email: 'email@example.com',
+                        description: 'A new charge from testing Pin gem',
+                        amount: '400',
+                        currency: 'AUD',
+                        ip_address: '127.0.0.1',
+                        card: {
+                          number: '5520000000000000',
+                          expiry_month: '05',
+                          expiry_year: '2012',
+                          cvc: '123',
+                          name: 'Roland Robot',
+                          address_line1: '42 Sevenoaks St',
+                          address_city: 'Lathlain',
+                          address_postcode: '6454',
+                          address_state: 'WA',
+                          address_country: 'Australia'
+                        } }
   end
 
   it 'should raise a 404 error when looking for a customer that doesn\'t exist' do
@@ -15,7 +46,7 @@ describe 'Errors', :vcr, class: Pin::PinError do
 
   it 'should raise a 422 error when trying to update missing a param' do
     options = { email: 'email@example.com', card: { address_line1: '12345 Fake Street', expiry_month: '05', expiry_year: Time.now.year+1, cvc: '123', address_city: 'Melbourne', address_postcode: '1234', address_state: 'VIC', address_country: 'Australia' } }
-    expect { Pin::Customer.update('cus_6XnfOD5bvQ1qkaf3LqmhfQ', options) }.to raise_error do |error|
+    expect { Pin::Customer.update(@customer_token, options) }.to raise_error do |error|
       expect(error).to be_a Pin::InvalidResource
       expect(error.message).to eq "card_number_invalid: Card number can't be blank card_name_invalid: Card name can't be blank "
       expect(error.response).to be_a Hash
@@ -23,19 +54,7 @@ describe 'Errors', :vcr, class: Pin::PinError do
   end
 
   it 'should raise a 422 error when trying to make a payment with an expired card' do
-    options = { email: 'email@example.com', description: 'A new charge from testing Pin gem', amount: '400', currency: 'AUD', ip_address: '127.0.0.1', card: {
-        number: '5520000000000000',
-        expiry_month: '05',
-        expiry_year: '2012',
-        cvc: '123',
-        name: 'Roland Robot',
-        address_line1: '42 Sevenoaks St',
-        address_city: 'Lathlain',
-        address_postcode: '6454',
-        address_state: 'WA',
-        address_country: 'Australia'
-      } }
-    expect { Pin::Charges.create(options) }.to raise_error do |error|
+    expect { Pin::Charges.create(@charge_options) }.to raise_error do |error|
       expect(error).to be_a Pin::InvalidResource
       expect(error.message).to eq 'card_expiry_month_invalid: Card expiry month is expired card_expiry_year_invalid: Card expiry year is expired '
       expect(error.response).to be_a Hash
@@ -43,34 +62,45 @@ describe 'Errors', :vcr, class: Pin::PinError do
   end
 
   it 'should raise a 400 error when trying to make a payment and a valid card gets declined' do
-    options = { email: 'email@example.com', description: 'A new charge from testing Pin gem', amount: '400', currency: 'AUD', ip_address: '127.0.0.1', card: {
-        number: '5560000000000001',
-        expiry_month: '05',
-        expiry_year: '2018',
-        cvc: '123',
-        name: 'Roland Robot',
-        address_line1: '42 Sevenoaks St',
-        address_city: 'Lathlain',
-        address_postcode: '6454',
-        address_state: 'WA',
-        address_country: 'Australia'
-      } }
+    options = { email: 'email@example.com',
+                description: 'A new charge from testing Pin gem',
+                amount: '400',
+                currency: 'AUD',
+                ip_address: '127.0.0.1',
+                card: {
+                  number: '5560000000000001',
+                  expiry_month: '05',
+                  expiry_year: '2018',
+                  cvc: '123',
+                  name: 'Roland Robot',
+                  address_line1: '42 Sevenoaks St',
+                  address_city: 'Lathlain',
+                  address_postcode: '6454',
+                  address_state: 'WA',
+                  address_country: 'Australia'
+                } }
     expect { Pin::Charges.create(options) }.to raise_error(Pin::ChargeError)
   end
 
   it 'should raise a 422 error when trying to make a payment with an invalid card' do
-    options = { email: 'email@example.com', description: 'A new charge from testing Pin gem', amount: '400', currency: 'AUD', ip_address: '127.0.0.1', card: {
-        number: '5520000000000099',
-        expiry_month: '05',
-        expiry_year: '2019',
-        cvc: '123',
-        name: 'Roland Robot',
-        address_line1: '42 Sevenoaks St',
-        address_city: 'Lathlain',
-        address_postcode: '6454',
-        address_state: 'WA',
-        address_country: 'Australia'
-      } }
+    options = { email: 'email@example.com',
+                description: 'A new charge from testing Pin gem',
+                amount: '400',
+                currency: 'AUD',
+                ip_address: '127.0.0.1',
+                card: {
+                  number: '5520000000000099',
+                  expiry_month: '05',
+                  expiry_year: '2019',
+                  cvc: '123',
+                  name: 'Roland Robot',
+                  address_line1: '42 Sevenoaks St',
+                  address_city: 'Lathlain',
+                  address_postcode: '6454',
+                  address_state: 'WA',
+                  address_country: 'Australia'
+                } }
+
     expect { Pin::Charges.create(options) }.to raise_error do |error|
       expect(error).to be_a Pin::InvalidResource
       expect(error.message).to eq 'card_number_invalid: Card number is not valid '
@@ -98,10 +128,9 @@ describe 'Errors', :vcr, class: Pin::PinError do
   end
 
   it 'should raise a 400 error when attempting to delete customer\'s primary card' do
-    customer_token = 'cus_6XnfOD5bvQ1qkaf3LqmhfQ'
-    cards = Pin::Customer.cards(customer_token)
+    cards = Pin::Customer.cards(@customer_token)
     primary_card_token = cards.select{|card| card['primary'] }.first['token']
-    expect { Pin::Customer.delete_card(customer_token, primary_card_token) }.to raise_error do |error|
+    expect { Pin::Customer.delete_card(@customer_token, primary_card_token) }.to raise_error do |error|
       expect(error).to be_a Pin::InvalidResource
       expect(error.message).to eq 'You cannot delete a customer\'s primary card token'
       expect(error.response).to be_a Hash

--- a/spec/recipients_spec.rb
+++ b/spec/recipients_spec.rb
@@ -3,11 +3,17 @@ require 'spec_helper'
 describe Pin::Recipient, :vcr do
   before(:each) do
     Pin::Base.new(ENV['PIN_SECRET'], :test)
+    @options = { email: 'hello@example.com',
+                 name: 'Roland Robot',
+                 bank_account: {
+                   name: 'Roland Robot',
+                   bsb: '123456',
+                   number: 987654321
+                 } }
   end
 
   it 'should create a new recipient' do
-    options = { email: 'hello@example.com', name: 'Roland Robot', bank_account: { name: 'Roland Robot', bsb: '123456', number: 987654321 } }
-    expect(Pin::Recipient.create(options)['token']).to match(/^[a-z]{2}[_]/)
+    expect(Pin::Recipient.create(@options)['token']).to match(/^[a-z]{2}[_]/)
   end
 
   it 'lists out recipients' do
@@ -15,22 +21,18 @@ describe Pin::Recipient, :vcr do
   end
 
   it 'gets a recipient given a token' do
-    options = { email: 'hello@example.com', name: 'Roland Robot', bank_account: { name: 'Roland Robot', bsb: '123456', number: 987654321 } }
-    recipient = Pin::Recipient.create(options)
+    recipient = Pin::Recipient.create(@options)
     expect(Pin::Recipient.find(recipient['token'])['token']).to eq recipient['token']
   end
 
   it 'updates the given details of a recipient and returns its details' do
-    options = { email: 'hello@example.com', name: 'Roland Robot', bank_account: { name: 'Roland Robot', bsb: '123456', number: 987654321 } }
-    recipient = Pin::Recipient.create(options)
+    recipient = Pin::Recipient.create(@options)
     updated_options = { email: 'new_email@example.com' }
     expect(Pin::Recipient.update(recipient['token'], updated_options)['email']).to eq 'new_email@example.com'
   end
 
   it 'returns a list of recipients transfers' do
-    options = { email: 'hello@example.com', name: 'Roland Robot', bank_account: { name: 'Roland Robot', bsb: '123456', number: 987654321 } }
-    recipient = Pin::Recipient.create(options)
-
+    recipient = Pin::Recipient.create(@options)
     transfer = { amount: 400, currency: 'AUD', description: 'Pay day', recipient: recipient['token'] }
     Pin::Transfer.create(transfer)
 

--- a/spec/refund_spec.rb
+++ b/spec/refund_spec.rb
@@ -3,25 +3,51 @@ require 'spec_helper'
 describe 'Refund', :vcr, class: Pin::Refund do
   before(:each) do
     Pin::Base.new(ENV['PIN_SECRET'], :test)
+    @options = { number: '5520000000000000',
+                expiry_month: '12',
+                expiry_year: Time.now.year+1,
+                cvc: '123',
+                name: 'Roland Robot',
+                address_line1: '123 Fake Street',
+                address_city: 'Melbourne',
+                address_postcode: '1234',
+                address_state: 'Vic',
+                address_country: 'Australia' }
+
+    @customer_token = Pin::Customer.create('email@example.com', @options)['token']
+
+    @charge = Pin::Charges.create(email: 'email@example.com',
+                                  description: 'Charge description',
+                                  amount: '500',
+                                  currency: 'AUD',
+                                  number: '5520000000000000',
+                                  ip_address: '203.192.1.172',
+                                  customer_token: @customer_token)
+
+    @no_refund_charge = Pin::Charges.create(email: 'email@example.com',
+                                            description: 'Charge description',
+                                            amount: '500',
+                                            currency: 'AUD',
+                                            number: '5520000000000000',
+                                            ip_address: '203.192.1.172',
+                                            customer_token: @customer_token)
+    Pin::Refund.create(@charge['token'], '400')
+    @refunds_charge_token = @charge['token']
   end
 
   it 'should list all refunds made to a charge given a token' do
-    expect(Pin::Refund.find('ch_5q0DiDnHZIggDfVDqcP-jQ')[0]['token']).to match(/^[a-z]{2}[_]/)
+    expect(Pin::Refund.find(@refunds_charge_token)[0]['token']).to match(/^[a-z]{2}[_]/)
   end
 
   it 'should return nothing if looking for a charge without a refund' do
-    expect(Pin::Refund.find('ch_Dsd62Ey5Hmd3B1dDHNKYvA')).to eq []
+    expect(Pin::Refund.find(@no_refund_charge['token'])).to eq []
   end
 
   it 'should return a page of refunds given a page and token' do
-    expect(Pin::Refund.find('ch_5q0DiDnHZIggDfVDqcP-jQ', 1, true)[:response]).to_not eq []
+    expect(Pin::Refund.find(@refunds_charge_token, 1, true)[:response]).to_not eq []
   end
 
   it 'should create a refund for a given amount and charge' do
-    customer = Pin::Customer.create('email@example.com', number: '5520000000000000', expiry_month: '12', expiry_year: Time.now.year+1, cvc: '123', name: 'Roland Robot', address_line1: '123 fake street', address_city: 'Melbourne', address_postcode: '1234', address_state: 'Vic', address_country: 'Australia')
-    options = { email: 'email@example.com', description: 'A new charge from testing Pin gem', amount: '400', currency: 'AUD', ip_address: '127.0.0.1', customer_token: customer['token']}
-    @charge = Pin::Charges.create(options)
-    expect(Pin::Refund.create(@charge['token'], '400')['amount']).to eq 400
+    expect(Pin::Refund.find(@refunds_charge_token)[0]['amount']).to eq 400
   end
-
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,7 +25,8 @@ RSpec.configure do |config|
           .metadata[:full_description]
           .split(/\s+/, 2).join('/')
           .gsub(/[^\w\/]+/, '_')
-    VCR.use_cassette(name) { example.call }
+    options = example.metadata.slice(:record, :match_on_requests_on)
+    VCR.use_cassette(name, options) { example.call }
   end
 end
 
@@ -33,5 +34,4 @@ VCR.configure do |c|
   c.cassette_library_dir = 'spec/vcr'
   c.hook_into :webmock
   c.allow_http_connections_when_no_cassette = true
-  c.filter_sensitive_data('<key>') { ENV['PIN_SECRET'] }
 end

--- a/spec/webhook_endpoints_spec.rb
+++ b/spec/webhook_endpoints_spec.rb
@@ -3,45 +3,32 @@ require 'spec_helper'
 RSpec.describe 'WebhookEndpoints', :vcr, class: Pin::WebhookEndpoints do
   before(:each) do
     Pin::Base.new(ENV['PIN_SECRET'], :test)
+    options = { url: "http://example.com/webhooks#{Time.now.to_i}/" }
+    @token = Pin::WebhookEndpoints.create(options)['token']
   end
 
   it 'should create a webhook endpoint and returns its details' do
-    options = { url: "http://example.com/webhooks#{Time.now.to_i}/" }
-    token = Pin::WebhookEndpoints.create(options)['token']
-    expect(token).to match(/^whe_/)
-    Pin::WebhookEndpoints.delete(token) # since we are only allowed 5 or so sandbox webhooks
+    expect(@token).to match(/^whe_/)
+    Pin::WebhookEndpoints.delete(@token) # since we are only allowed 5 or so sandbox webhooks
   end
 
   it 'should list webhook endpoints' do
-    options = { url: "http://example.com/webhooks#{Time.now.to_i}/" }
-    token = Pin::WebhookEndpoints.create(options)['token']
     expect(Pin::WebhookEndpoints.all).to_not eq []
-    Pin::WebhookEndpoints.delete(token) # since we are only allowed 5 or so sandbox webhooks
+    Pin::WebhookEndpoints.delete(@token) # since we are only allowed 5 or so sandbox webhooks
   end
 
   it 'should list webhook endpoint on a page given a page' do
     request = Pin::WebhookEndpoints.all(1, true)
-    options = { url: "http://example.com/webhooks#{Time.now.to_i}/" }
-    token = Pin::WebhookEndpoints.create(options)['token']
-
     expect(request[:response]).to_not eq []
-
-    Pin::WebhookEndpoints.delete(token) # since we are only allowed 5 or so sandbox webhooks
+    Pin::WebhookEndpoints.delete(@token) # since we are only allowed 5 or so sandbox webhooks
   end
 
   it 'should show a webhook endpoint given a token' do
-    options = { url: "http://example.com/webhooks#{Time.now.to_i}/" }
-    token = Pin::WebhookEndpoints.create(options)['token']
-
-    expect(Pin::WebhookEndpoints.find(token)['token']).to eq token
-
-    Pin::WebhookEndpoints.delete(token) # since we are only allowed 5 or so sandbox webhooks
+    expect(Pin::WebhookEndpoints.find(@token)['token']).to eq @token
+    Pin::WebhookEndpoints.delete(@token) # since we are only allowed 5 or so sandbox webhooks
   end
 
   it 'should delete a webhook endpoint given a token' do
-    options = { url: "http://example.com/webhooks_delete#{Time.now.to_i}/" }
-    token = Pin::WebhookEndpoints.create(options)['token']
-
-    expect(Pin::WebhookEndpoints.delete(token).response.code).to eq "204"
+    expect(Pin::WebhookEndpoints.delete(@token).response.code).to eq "204"
   end
 end


### PR DESCRIPTION
I ran into a little stumbling block regarding the tests.  
I wanted to add to pin_up and first that meant getting the tests working. However, I did find that updating the VCR cassettes using my Secret Pin Payment Pin broke a lot of tests because my Pin Payment data is different to pin_up's Pin Payment test data. 

I would like to make the tests very easy to update (i.e updating VCR cassettes), easy to extend tests for future features and easy for new contributors to add to this project.

To overcome this issue, I fixed all the tests so that they are data independent. This would enable all contributors to create VCR cassettes that will enable all tests to work off the bat! I also updated the documentation. 

I squashed all my commits into a single commit. If you would rather the individual commits then I can PR that branch. If you have any comments let me know :)