### PR TITLE
Decouple test from user API data & update readme

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,6 @@ source "http://rubygems.org"
 gem "httparty", ">= 0.11.0"
 
 group :development do
-  gem "shoulda", "~> 3.5"
   gem "rdoc", "~> 3.12"
   gem "rspec" #, "~> 2.13"
   gem "jeweler", "~> 2.1.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,6 @@
 GEM
   remote: http://rubygems.org/
   specs:
-    activesupport (5.1.0)
-      concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (~> 0.7)
-      minitest (~> 5.1)
-      tzinfo (~> 1.1)
     addressable (2.3.8)
     builder (3.2.2)
     celluloid (0.16.0)
@@ -13,7 +8,6 @@ GEM
     codeclimate-test-reporter (0.4.7)
       simplecov (>= 0.7.1, < 1.0.0)
     coderay (1.1.0)
-    concurrent-ruby (1.0.5)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     descendants_tracker (0.0.4)
@@ -53,7 +47,6 @@ GEM
     httparty (0.13.5)
       json (~> 1.8)
       multi_xml (>= 0.5.2)
-    i18n (0.8.1)
     jeweler (2.1.1)
       builder
       bundler (>= 1.0)
@@ -73,7 +66,6 @@ GEM
     lumberjack (1.0.9)
     method_source (0.8.2)
     mini_portile2 (2.1.0)
-    minitest (5.10.1)
     multi_json (1.11.0)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
@@ -118,12 +110,6 @@ GEM
     safe_yaml (1.0.4)
     semver (1.0.1)
     shellany (0.0.1)
-    shoulda (3.5.0)
-      shoulda-context (~> 1.0, >= 1.0.1)
-      shoulda-matchers (>= 1.4.1, < 3.0)
-    shoulda-context (1.2.2)
-    shoulda-matchers (2.8.0)
-      activesupport (>= 3.0.0)
     simplecov (0.7.1)
       multi_json (~> 1.0)
       simplecov-html (~> 0.7.1)
@@ -134,8 +120,6 @@ GEM
     thread_safe (0.3.5)
     timers (4.0.1)
       hitimes
-    tzinfo (1.2.3)
-      thread_safe (~> 0.1)
     vcr (3.0.3)
     webmock (3.0.1)
       addressable (>= 2.3.6)
@@ -152,11 +136,10 @@ DEPENDENCIES
   jeweler (~> 2.1.1)
   rdoc (~> 3.12)
   rspec
-  shoulda (~> 3.5)
   simplecov (~> 0.7.1)
   terminal-notifier-guard (~> 1.5.3)
   vcr
   webmock
 
 BUNDLED WITH
-   1.14.5
+   1.16.1

--- a/README.md
+++ b/README.md
@@ -308,11 +308,32 @@ Create a YAML file under 'spec' called 'test_data.yml' and add in:
 
     PIN_SECRET: "your pin test secret"
 
-uncomment line 13 in spec_helper.rb and
+uncomment line 16 in spec_helper.rb and
 
 run
 
     rspec spec/*.rb
+
+### Record New VCR cassettes
+After cloning the project one should create a new set of cassettes.
+
+In spec_helper change 
+
+    VCR.use_cassette(name, options) { example.call }
+to
+
+    VCR.use_cassette(name, record: :all) { example.call }
+
+Run all tests and then change the line back (replace record: :all with options)
+
+### Updating VCR test cassettes
+A contributor can update cassettes previously recorded by adding the following syntax:
+     
+     record: :all, :match_requests_on => [:method, :host, :path]
+
+E.g. in a particular spec file:
+
+    describe Pin::Balance, :vcr, record: :all, :match_requests_on => [:method, :host, :path] do
 
 ## Contributing to pin_up
 

--- a/spec/cards_spec.rb
+++ b/spec/cards_spec.rb
@@ -1,12 +1,24 @@
 require 'spec_helper'
 
 RSpec.describe 'Card', :vcr, class: Pin::Card do
+  let(:card_1) {
+    { number: '5520000000000000',
+      expiry_month: '12',
+      expiry_year: '2025',
+      cvc: '123',
+      name: 'Roland Robot',
+      address_line1: '123 Fake Street',
+      address_city: 'Melbourne',
+      address_postcode: '1234',
+      address_state: 'Vic',
+      address_country: 'Australia' }
+  }
+
   before(:each) do
     Pin::Base.new(ENV['PIN_SECRET'], :test)
   end
 
   it 'should create a card and respond with the card detail from pin' do
-    options = { number: '5520000000000000', expiry_month: '12', expiry_year: '2018', cvc: '123', name: 'Roland Robot', address_line1: '123 Fake Road', address_line2: '', address_city: 'Melbourne', address_postcode: '1223', address_state: 'Vic', address_country: 'AU' }
-    expect(Pin::Card.create(options)['token']).to match(/^[a-z]{4}[_]/)
+    expect(Pin::Card.create(card_1)['token']).to match(/^[a-z]{4}[_]/)
   end
 end

--- a/spec/charges_spec.rb
+++ b/spec/charges_spec.rb
@@ -1,8 +1,58 @@
 require 'spec_helper'
 
 describe 'Charge', :vcr, class: Pin::Charges do
+  let(:card_1) {
+    { number: '5520000000000000',
+      expiry_month: '12',
+      expiry_year: '2025',
+      cvc: '123',
+      name: 'Roland Robot',
+      address_line1: '123 Fake Street',
+      address_city: 'Melbourne',
+      address_postcode: '1234',
+      address_state: 'Vic',
+      address_country: 'Australia' }
+  }
+
+  let(:customer_token) {
+    Pin::Customer.create('email@example.com', card_1)['token']
+  }
+
+  let(:charge) {
+    Pin::Charges.create(email: 'email@example.com',
+                        description: 'Charge description',
+                        amount: '500',
+                        currency: 'AUD',
+                        number: '5520000000000000',
+                        ip_address: '203.192.1.172',
+                        customer_token: customer_token)
+  }
+
+  let(:charge_hash) {
+    { email: 'email@example.com',
+      description: 'A new charge from testing Pin gem',
+      amount: '400',
+      currency: 'AUD',
+      ip_address: '127.0.0.1',
+      customer_token: customer_token }
+  }
+
+  let(:charge_capture_false) {
+    { email: 'email@example.com',
+      description: 'A new captured charge from testing Pin gem',
+      amount: '400',
+      currency: 'AUD',
+      ip_address: '127.0.0.1',
+      customer_token: customer_token,
+      capture: false }
+  }
+
   before(:each) do
     Pin::Base.new(ENV['PIN_SECRET'], :test)
+    # Create a customer
+    customer_token
+    # Create a charge
+    charge
   end
 
   it 'should list charges in Pin' do
@@ -14,17 +64,15 @@ describe 'Charge', :vcr, class: Pin::Charges do
   end
 
   it 'should create a charge given details' do
-    customer = Pin::Customer.create('email@example.com', number: '5520000000000000', expiry_month: '12', expiry_year: Time.now.year+1, cvc: '123', name: 'Roland Robot', address_line1: '123 fake street', address_city: 'Melbourne', address_postcode: '1234', address_state: 'Vic', address_country: 'Australia')
-    options = { email: 'email@example.com', description: 'A new charge from testing Pin gem', amount: '400', currency: 'AUD', ip_address: '127.0.0.1', customer_token: customer['token'] }
-    expect(Pin::Charges.create(options)['success']).to eq true
+    expect(Pin::Charges.create(charge_hash)['success']).to eq true
   end
 
   it 'should show a charge given a token' do
-    expect(Pin::Charges.find('ch_YFEgBSs5qTIWggGt72jn7Q')['token']).to match(/^[a-z]{2}[_]/)
+    expect(Pin::Charges.find(charge['token'])['token']).to match(/^[a-z]{2}[_]/)
   end
 
   it 'should show a charge given a search term' do
-    expect(Pin::Charges.search(query: 'A new charge from testing Pin gem', end_date: 'Aug 31, 2016')).to_not eq []
+    expect(Pin::Charges.search(query: 'Charge Desc', end_date: 'Aug 31, 2025')).to_not eq []
   end
 
   it 'should return pagination if "pagination" is true' do
@@ -36,23 +84,19 @@ describe 'Charge', :vcr, class: Pin::Charges do
   end
 
   it 'should return pagination for search if "pagination" is true' do
-    expect(Pin::Charges.search(3, true, query: 'A new charge from testing Pin gem', end_date: 'Aug 31, 2016')[:pagination]['current']).to eq 3
+    expect(Pin::Charges.search(3, true, query: 'Charge Desc', end_date: 'Aug 31, 2025')[:pagination]['current']).to eq 3
   end
 
   it 'should list charges for search on a page given a page' do
-    expect(Pin::Charges.search(1, query: 'A new charge from testing Pin gem', end_date: 'Aug 31, 2016')).to_not eq []
+    expect(Pin::Charges.search(1, query: 'Charge Desc', end_date: 'Aug 31, 2025')).to_not eq []
   end
 
   it 'should create a pre-auth (capture a charge)' do
-    customer = Pin::Customer.create('email@example.com', number: '5520000000000000', expiry_month: '12', expiry_year: Time.now.year+1, cvc: '123', name: 'Roland Robot', address_line1: '123 fake street', address_city: 'Melbourne', address_postcode: '1234', address_state: 'Vic', address_country: 'Australia')
-    options = { email: 'email@example.com', description: 'A new captured charge from testing Pin gem', amount: '400', currency: 'AUD', ip_address: '127.0.0.1', customer_token: customer['token'], capture: false }
-    expect(Pin::Charges.create(options)['captured']).to eq false
+    expect(Pin::Charges.create(charge_capture_false)['captured']).to eq false
   end
 
   it 'should capture a charge' do
-    customer = Pin::Customer.create('email@example.com', number: '5520000000000000', expiry_month: '12', expiry_year: Time.now.year+1, cvc: '123', name: 'Roland Robot', address_line1: '123 fake street', address_city: 'Melbourne', address_postcode: '1234', address_state: 'Vic', address_country: 'Australia')
-    options = { email: 'email@example.com', description: 'A new captured charge from testing Pin gem', amount: '400', currency: 'AUD', ip_address: '127.0.0.1', customer_token: customer['token'], capture: false }
-    token = Pin::Charges.create(options)['token']
+    token = Pin::Charges.create(charge_capture_false)['token']
     expect(Pin::Charges.capture(token)['success']).to eq true
   end
 end

--- a/spec/customers_spec.rb
+++ b/spec/customers_spec.rb
@@ -1,8 +1,46 @@
 require 'spec_helper'
 
 describe 'Customer', :vcr, class: Pin::Customer do
+  let(:card_1) {
+    { number: '5520000000000000',
+      expiry_month: '12',
+      expiry_year: '2025',
+      cvc: '123',
+      name: 'Roland Robot',
+      address_line1: '123 Fake Street',
+      address_city: 'Melbourne',
+      address_postcode: '1234',
+      address_state: 'Vic',
+      address_country: 'Australia' }
+  }
+
+  let(:card_2) {
+    { number: '4200000000000000',
+      expiry_month: '12',
+      expiry_year: '2020',
+      cvc: '111',
+      name: 'Roland TestRobot',
+      address_line1: '123 Fake Road',
+      address_line2: '',
+      address_city: 'Melbourne',
+      address_postcode: '1223',
+      address_state: 'Vic',
+      address_country: 'AU' }
+  }
+
+  let(:customer_token) {
+    Pin::Customer.create('email@example.com', card_1)['token']
+  }
+
   before(:each) do
     Pin::Base.new(ENV['PIN_SECRET'], :test)
+    Pin::Charges.create(email: 'email@example.com',
+                        description: 'Charge description',
+                        amount: '500',
+                        currency: 'AUD',
+                        number: '5520000000000000',
+                        ip_address: '203.192.1.172',
+                        customer_token: customer_token)
   end
 
   it 'should list customers' do
@@ -30,60 +68,52 @@ describe 'Customer', :vcr, class: Pin::Customer do
   end
 
   it 'should show a customer given a token' do
-    expect(Pin::Customer.find('cus_6XnfOD5bvQ1qkaf3LqmhfQ')['token']).to eq 'cus_6XnfOD5bvQ1qkaf3LqmhfQ'
+    expect(Pin::Customer.find(customer_token)['token']).to eq(customer_token)
   end
 
   it 'should list charges to a customer given a token' do
-    expect(Pin::Customer.charges('cus_6XnfOD5bvQ1qkaf3LqmhfQ')[0]['token']).to match(/^[a-z]{2}[_]/)
+    Pin::Customer.charges(customer_token)
+    expect(Pin::Customer.charges(customer_token)[0]['token']).to match(/^[a-z]{2}[_]/)
   end
 
   it 'should show pagination on a page given a token and a page' do
-    expect(Pin::Customer.charges('cus_6XnfOD5bvQ1qkaf3LqmhfQ', 5, true)[:pagination]['current']).to eq 5
+    expect(Pin::Customer.charges(customer_token, 5, true)[:pagination]['current']).to eq 5
   end
 
   it 'should list charges to a customer on a page given a token and a page' do
-    expect(Pin::Customer.charges('cus_6XnfOD5bvQ1qkaf3LqmhfQ', 1, true)[:response][0]['token']).to match(/^[a-z]{2}[_]/)
+    expect(Pin::Customer.charges(customer_token, 1, true)[:response][0]['token']).to match(/^[a-z]{2}[_]/)
   end
 
   it 'should create a customer given an email and card details' do
-    expect(Pin::Customer.create('email@example.com', number: '5520000000000000', expiry_month: '12', expiry_year: '2020', cvc: '123', name: 'Roland Robot', address_line1: '123 fake street', address_city: 'Melbourne', address_postcode: '1234', address_state: 'Vic', address_country: 'Australia')['token']).to match(/^[a-z]{3}[_]/)
+    expect(Pin::Customer.create('email@example.com', card_1)['token']).to match(/^[a-z]{3}[_]/)
   end
 
   it 'should update a customer given a token and details to update' do
-    options = { email: 'email@example.com', card: { number: '5520000000000000', address_line1: '12345 Fake Street', expiry_month: '05', expiry_year: Time.now.year+1, cvc: '123', name: 'Daniel Nitsikopoulos', address_city: 'Melbourne', address_postcode: '1234', address_state: 'VIC', address_country: 'Australia' } }
-    expect(Pin::Customer.update('cus_6XnfOD5bvQ1qkaf3LqmhfQ', options)['card']['address_line1']).to eq '12345 Fake Street'
+    expect(Pin::Customer.update(customer_token, card_1)['card']['address_line1']).to eq '123 Fake Street'
   end
 
   it 'should create a customer given a card token customer email' do
-    options = { number: '5520000000000000', expiry_month: '12', expiry_year: '2018', cvc: '123', name: 'Roland TestRobot', address_line1: '123 Fake Road', address_line2: '', address_city: 'Melbourne', address_postcode: '1223', address_state: 'Vic', address_country: 'AU' }
-    @card = Pin::Card.create(options)
+    @card = Pin::Card.create(card_1)
     expect(Pin::Customer.create('nitza98@hotmail.com', @card['token'])['token']).to match(/^[a-z]{3}[_]/)
   end
 
   it 'should list all cards belonging to this customer' do
-    token = 'cus_6XnfOD5bvQ1qkaf3LqmhfQ'
-    expect(Pin::Customer.cards(token).first['token']).to match(/(card)[_]([\w-]{22})/)
+    expect(Pin::Customer.cards(customer_token).first['token']).to match(/(card)[_]([\w-]{22})/)
   end
 
   it 'should create a card given customer token and card hash' do
-    customer_token = 'cus_6XnfOD5bvQ1qkaf3LqmhfQ'
-    card = { publishable_api_key: ENV['PUBLISHABLE_SECRET'], number: '5520000000000000', expiry_month: '12', expiry_year: '2018', cvc: '123', name: 'Roland TestRobot', address_line1: '123 Fake Road', address_line2: '', address_city: 'Melbourne', address_postcode: '1223', address_state: 'Vic', address_country: 'AU' }
-    expect(Pin::Customer.create_card(customer_token, card)['token']).to match(/(card)[_]([\w-]{22})/)
+    # card = { publishable_api_key: ENV['PUBLISHABLE_SECRET'], number: '5520000000000000', expiry_month: '12', expiry_year: '2018', cvc: '123', name: 'Roland TestRobot', address_line1: '123 Fake Road', address_line2: '', address_city: 'Melbourne', address_postcode: '1223', address_state: 'Vic', address_country: 'AU' }
+    expect(Pin::Customer.create_card(customer_token, card_1)['token']).to match(/(card)[_]([\w-]{22})/)
   end
 
   it 'should create a card then add it to a customer' do
-    options = { number: '5520000000000000', expiry_month: '12', expiry_year: '2018', cvc: '123', name: 'Roland Robot', address_line1: '123 Fake Road', address_line2: '', address_city: 'Melbourne', address_postcode: '1223', address_state: 'Vic', address_country: 'AU' }
-    card_token = Pin::Card.create(options)['token']
-    customer_token = 'cus_6XnfOD5bvQ1qkaf3LqmhfQ'
-    expect(Pin::Customer.create_card(customer_token, card_token)['token']).to match(/(card)[_]([\w-]{22})/)
+    added_card = Pin::Customer.create_card(customer_token, card_2)
+    expect(added_card['token']).to match(/(card)[_]([\w-]{22})/)
   end
 
   it 'should delete a card given a token' do
-    options = { number: '5520000000000000', expiry_month: '12', expiry_year: '2018', cvc: '123', name: 'Roland Robot', address_line1: '123 Fake Road', address_line2: '', address_city: 'Melbourne', address_postcode: '1223', address_state: 'Vic', address_country: 'AU' }
-    card_token = Pin::Card.create(options)['token']
-    customer_token = 'cus_6XnfOD5bvQ1qkaf3LqmhfQ'
+    card_token = Pin::Card.create(card_2)['token']
     Pin::Customer.create_card(customer_token, card_token)
     expect(Pin::Customer.delete_card(customer_token, card_token).code).to eq 204
   end
-
 end

--- a/spec/errors_spec.rb
+++ b/spec/errors_spec.rb
@@ -1,6 +1,73 @@
 require 'spec_helper'
 
 describe 'Errors', :vcr, class: Pin::PinError do
+  let(:card_1) {
+    { number: '5520000000000000',
+      expiry_month: '12',
+      expiry_year: '2025',
+      cvc: '123',
+      name: 'Roland Robot',
+      address_line1: '123 Fake Street',
+      address_city: 'Melbourne',
+      address_postcode: '1234',
+      address_state: 'Vic',
+      address_country: 'Australia' }
+  }
+
+  let(:customer_token) {
+    Pin::Customer.create('email@example.com', card_1)['token']
+  }
+
+  let(:charge_hash) {
+    { email: 'email@example.com',
+      description: 'A new charge from testing Pin gem',
+      amount: '400',
+      currency: 'AUD',
+      ip_address: '127.0.0.1',
+      card: {
+        number: '5520000000000000',
+        expiry_month: '05',
+        expiry_year: '2012',
+        cvc: '123',
+        name: 'Roland Robot',
+        address_line1: '42 Sevenoaks St',
+        address_city: 'Lathlain',
+        address_postcode: '6454',
+        address_state: 'WA',
+        address_country: 'Australia'
+      } }
+  }
+
+  let(:hash_of_details) {
+    { email: 'email@example.com',
+      description: 'A new charge from testing Pin gem',
+      amount: '400',
+      currency: 'AUD',
+      ip_address: '127.0.0.1',
+      card: {
+        number: '5560000000000001',
+        expiry_month: '05',
+        expiry_year: '2018',
+        cvc: '123',
+        name: 'Roland Robot',
+        address_line1: '42 Sevenoaks St',
+        address_city: 'Lathlain',
+        address_postcode: '6454',
+        address_state: 'WA',
+        address_country: 'Australia'
+      } }
+  }
+
+  let(:charge) {
+    Pin::Charges.create(email: 'email@example.com',
+                        description: 'Charge description',
+                        amount: '500',
+                        currency: 'AUD',
+                        number: '5520000000000000',
+                        ip_address: '203.192.1.172',
+                        customer_token: customer_token)
+  }
+
   before(:each) do
     Pin::Base.new(ENV['PIN_SECRET'], :test)
   end
@@ -14,8 +81,11 @@ describe 'Errors', :vcr, class: Pin::PinError do
   end
 
   it 'should raise a 422 error when trying to update missing a param' do
-    options = { email: 'email@example.com', card: { address_line1: '12345 Fake Street', expiry_month: '05', expiry_year: Time.now.year+1, cvc: '123', address_city: 'Melbourne', address_postcode: '1234', address_state: 'VIC', address_country: 'Australia' } }
-    expect { Pin::Customer.update('cus_6XnfOD5bvQ1qkaf3LqmhfQ', options) }.to raise_error do |error|
+    hash_w_no_credit_card_or_name = hash_of_details.tap do |h|
+      h[:card][:number] = ''
+      h[:card][:name] = ''
+    end
+    expect { Pin::Customer.update(customer_token, hash_w_no_credit_card_or_name) }.to raise_error do |error|
       expect(error).to be_a Pin::InvalidResource
       expect(error.message).to eq "card_number_invalid: Card number can't be blank card_name_invalid: Card name can't be blank "
       expect(error.response).to be_a Hash
@@ -23,19 +93,10 @@ describe 'Errors', :vcr, class: Pin::PinError do
   end
 
   it 'should raise a 422 error when trying to make a payment with an expired card' do
-    options = { email: 'email@example.com', description: 'A new charge from testing Pin gem', amount: '400', currency: 'AUD', ip_address: '127.0.0.1', card: {
-        number: '5520000000000000',
-        expiry_month: '05',
-        expiry_year: '2012',
-        cvc: '123',
-        name: 'Roland Robot',
-        address_line1: '42 Sevenoaks St',
-        address_city: 'Lathlain',
-        address_postcode: '6454',
-        address_state: 'WA',
-        address_country: 'Australia'
-      } }
-    expect { Pin::Charges.create(options) }.to raise_error do |error|
+    hash_w_expired_credit_card = hash_of_details.tap do |h|
+      h[:card][:expiry_year] = '2001'
+    end
+    expect { Pin::Charges.create(hash_w_expired_credit_card) }.to raise_error do |error|
       expect(error).to be_a Pin::InvalidResource
       expect(error.message).to eq 'card_expiry_month_invalid: Card expiry month is expired card_expiry_year_invalid: Card expiry year is expired '
       expect(error.response).to be_a Hash
@@ -43,35 +104,17 @@ describe 'Errors', :vcr, class: Pin::PinError do
   end
 
   it 'should raise a 400 error when trying to make a payment and a valid card gets declined' do
-    options = { email: 'email@example.com', description: 'A new charge from testing Pin gem', amount: '400', currency: 'AUD', ip_address: '127.0.0.1', card: {
-        number: '5560000000000001',
-        expiry_month: '05',
-        expiry_year: '2018',
-        cvc: '123',
-        name: 'Roland Robot',
-        address_line1: '42 Sevenoaks St',
-        address_city: 'Lathlain',
-        address_postcode: '6454',
-        address_state: 'WA',
-        address_country: 'Australia'
-      } }
-    expect { Pin::Charges.create(options) }.to raise_error(Pin::ChargeError)
+    hash_w_card_declined = hash_of_details.tap do |h|
+      h[:card][:number] = '5560000000000001'
+    end
+    expect { Pin::Charges.create(hash_w_card_declined) }.to raise_error(Pin::ChargeError)
   end
 
   it 'should raise a 422 error when trying to make a payment with an invalid card' do
-    options = { email: 'email@example.com', description: 'A new charge from testing Pin gem', amount: '400', currency: 'AUD', ip_address: '127.0.0.1', card: {
-        number: '5520000000000099',
-        expiry_month: '05',
-        expiry_year: '2019',
-        cvc: '123',
-        name: 'Roland Robot',
-        address_line1: '42 Sevenoaks St',
-        address_city: 'Lathlain',
-        address_postcode: '6454',
-        address_state: 'WA',
-        address_country: 'Australia'
-      } }
-    expect { Pin::Charges.create(options) }.to raise_error do |error|
+     hash_w_invalid_card = hash_of_details.tap do |h|
+      h[:card][:number] = '5520000000000099'
+    end
+    expect { Pin::Charges.create(hash_w_invalid_card) }.to raise_error do |error|
       expect(error).to be_a Pin::InvalidResource
       expect(error.message).to eq 'card_number_invalid: Card number is not valid '
       expect(error.response).to be_a Hash
@@ -87,10 +130,7 @@ describe 'Errors', :vcr, class: Pin::PinError do
   end
 
   it 'should raise a 422 error if no 2nd argument is given' do
-    customer = Pin::Customer.create('email@example.com', number: '5520000000000000', expiry_month: '12', expiry_year: Time.now.year+1, cvc: '123', name: 'Roland Robot', address_line1: '123 fake street', address_city: 'Melbourne', address_postcode: '1234', address_state: 'Vic', address_country: 'Australia')
-    options = { email: 'email@example.com', description: 'A new charge from testing Pin gem', amount: '400', currency: 'AUD', ip_address: '127.0.0.1', customer_token: customer['token'] }
-    @charge = Pin::Charges.create(options)
-    expect { Pin::Refund.create(@charge['token']) }.to raise_error do |error|
+    expect { Pin::Refund.create(charge['token']) }.to raise_error do |error|
       expect(error).to be_a Pin::InvalidResource
       expect(error.message).to eq "amount_invalid: Amount can't be blank amount_invalid: Amount is not a number "
       expect(error.response).to be_a Hash
@@ -98,7 +138,6 @@ describe 'Errors', :vcr, class: Pin::PinError do
   end
 
   it 'should raise a 400 error when attempting to delete customer\'s primary card' do
-    customer_token = 'cus_6XnfOD5bvQ1qkaf3LqmhfQ'
     cards = Pin::Customer.cards(customer_token)
     primary_card_token = cards.select{|card| card['primary'] }.first['token']
     expect { Pin::Customer.delete_card(customer_token, primary_card_token) }.to raise_error do |error|
@@ -116,5 +155,4 @@ describe 'Errors', :vcr, class: Pin::PinError do
       expect(error.response).to be_a Hash
     end
   end
-
 end

--- a/spec/recipients_spec.rb
+++ b/spec/recipients_spec.rb
@@ -1,13 +1,22 @@
 require 'spec_helper'
 
 describe Pin::Recipient, :vcr do
+  let(:recipient_details) {
+    { email: 'hello@example.com',
+      name: 'Roland Robot',
+      bank_account: {
+        name: 'Roland Robot',
+        bsb: '123456',
+        number: 987654321
+      } }
+  }
+
   before(:each) do
     Pin::Base.new(ENV['PIN_SECRET'], :test)
   end
 
   it 'should create a new recipient' do
-    options = { email: 'hello@example.com', name: 'Roland Robot', bank_account: { name: 'Roland Robot', bsb: '123456', number: 987654321 } }
-    expect(Pin::Recipient.create(options)['token']).to match(/^[a-z]{2}[_]/)
+    expect(Pin::Recipient.create(recipient_details)['token']).to match(/^[a-z]{2}[_]/)
   end
 
   it 'lists out recipients' do
@@ -15,22 +24,18 @@ describe Pin::Recipient, :vcr do
   end
 
   it 'gets a recipient given a token' do
-    options = { email: 'hello@example.com', name: 'Roland Robot', bank_account: { name: 'Roland Robot', bsb: '123456', number: 987654321 } }
-    recipient = Pin::Recipient.create(options)
+    recipient = Pin::Recipient.create(recipient_details)
     expect(Pin::Recipient.find(recipient['token'])['token']).to eq recipient['token']
   end
 
   it 'updates the given details of a recipient and returns its details' do
-    options = { email: 'hello@example.com', name: 'Roland Robot', bank_account: { name: 'Roland Robot', bsb: '123456', number: 987654321 } }
-    recipient = Pin::Recipient.create(options)
+    recipient = Pin::Recipient.create(recipient_details)
     updated_options = { email: 'new_email@example.com' }
     expect(Pin::Recipient.update(recipient['token'], updated_options)['email']).to eq 'new_email@example.com'
   end
 
   it 'returns a list of recipients transfers' do
-    options = { email: 'hello@example.com', name: 'Roland Robot', bank_account: { name: 'Roland Robot', bsb: '123456', number: 987654321 } }
-    recipient = Pin::Recipient.create(options)
-
+    recipient = Pin::Recipient.create(recipient_details)
     transfer = { amount: 400, currency: 'AUD', description: 'Pay day', recipient: recipient['token'] }
     Pin::Transfer.create(transfer)
 

--- a/spec/refund_spec.rb
+++ b/spec/refund_spec.rb
@@ -1,27 +1,61 @@
 require 'spec_helper'
 
 describe 'Refund', :vcr, class: Pin::Refund do
+  let(:card_1) {
+    { number: '5520000000000000',
+     expiry_month: '12',
+     expiry_year: '2025',
+     cvc: '123',
+     name: 'Roland Robot',
+     address_line1: '123 Fake Street',
+     address_city: 'Melbourne',
+     address_postcode: '1234',
+     address_state: 'Vic',
+     address_country: 'Australia' }
+  }
+
+  let(:customer_token) {
+    Pin::Customer.create('email@example.com', card_1)['token']
+  }
+
+  let(:charge) {
+    Pin::Charges.create(email: 'email@example.com',
+                        description: 'Charge description',
+                        amount: '500',
+                        currency: 'AUD',
+                        number: '5520000000000000',
+                        ip_address: '203.192.1.172',
+                        customer_token: customer_token)
+  }
+
+  let(:no_refund_charge) {
+    Pin::Charges.create(email: 'email@example.com',
+                        description: 'Charge description',
+                        amount: '500',
+                        currency: 'AUD',
+                        number: '5520000000000000',
+                        ip_address: '203.192.1.172',
+                        customer_token: customer_token)
+  }
+
   before(:each) do
     Pin::Base.new(ENV['PIN_SECRET'], :test)
+    Pin::Refund.create(charge['token'], '400')
   end
 
   it 'should list all refunds made to a charge given a token' do
-    expect(Pin::Refund.find('ch_5q0DiDnHZIggDfVDqcP-jQ')[0]['token']).to match(/^[a-z]{2}[_]/)
+    expect(Pin::Refund.find(charge['token'])[0]['token']).to match(/^[a-z]{2}[_]/)
   end
 
   it 'should return nothing if looking for a charge without a refund' do
-    expect(Pin::Refund.find('ch_Dsd62Ey5Hmd3B1dDHNKYvA')).to eq []
+    expect(Pin::Refund.find(no_refund_charge['token'])).to eq []
   end
 
   it 'should return a page of refunds given a page and token' do
-    expect(Pin::Refund.find('ch_5q0DiDnHZIggDfVDqcP-jQ', 1, true)[:response]).to_not eq []
+    expect(Pin::Refund.find(charge['token'], 1, true)[:response]).to_not eq []
   end
 
   it 'should create a refund for a given amount and charge' do
-    customer = Pin::Customer.create('email@example.com', number: '5520000000000000', expiry_month: '12', expiry_year: Time.now.year+1, cvc: '123', name: 'Roland Robot', address_line1: '123 fake street', address_city: 'Melbourne', address_postcode: '1234', address_state: 'Vic', address_country: 'Australia')
-    options = { email: 'email@example.com', description: 'A new charge from testing Pin gem', amount: '400', currency: 'AUD', ip_address: '127.0.0.1', customer_token: customer['token']}
-    @charge = Pin::Charges.create(options)
-    expect(Pin::Refund.create(@charge['token'], '400')['amount']).to eq 400
+    expect(Pin::Refund.find(charge['token'])[0]['amount']).to eq 400
   end
-
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,7 +25,8 @@ RSpec.configure do |config|
           .metadata[:full_description]
           .split(/\s+/, 2).join('/')
           .gsub(/[^\w\/]+/, '_')
-    options = example.metadata.slice(:record, :match_on_requests_on)
+    valid_keys = %w[record match_on_requests_on]
+    options = example.metadata.select { |key,_| valid_keys.include? key }
     VCR.use_cassette(name, options) { example.call }
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,7 +25,8 @@ RSpec.configure do |config|
           .metadata[:full_description]
           .split(/\s+/, 2).join('/')
           .gsub(/[^\w\/]+/, '_')
-    VCR.use_cassette(name) { example.call }
+    options = example.metadata.slice(:record, :match_on_requests_on)
+    VCR.use_cassette(name, options) { example.call }
   end
 end
 
@@ -33,5 +34,4 @@ VCR.configure do |c|
   c.cassette_library_dir = 'spec/vcr'
   c.hook_into :webmock
   c.allow_http_connections_when_no_cassette = true
-  c.filter_sensitive_data('<key>') { ENV['PIN_SECRET'] }
 end

--- a/spec/transfers_spec.rb
+++ b/spec/transfers_spec.rb
@@ -1,25 +1,36 @@
 require 'spec_helper'
 
 describe Pin::Transfer, :vcr do
+  let(:recipient_hash) {
+    { email: 'test@example.com',
+      name: 'Roland Robot',
+      bank_account: { name: 'Roland Robot',
+                      bsb: '123456',
+                      number: 987654321 } }
+  }
+
+  let(:recipient) {
+    Pin::Recipient.create(recipient_hash)
+  }
+
+  let(:transfer) {
+    Pin::Transfer.create({ amount: 400,
+                           currency: 'AUD',
+                           description: 'Pay day',
+                           recipient: recipient['token'] })
+  }
+
   before(:each) do
     Pin::Base.new(ENV['PIN_SECRET'], :test)
   end
 
   it 'returns the line items associated with transfer' do
-    options ={ email: 'hello2@example.com', name: 'Roland Robot', bank_account: { name: 'Roland Robot', bsb: '123456', number: 987654321 } }
-    recipient = Pin::Recipient.create(options)
-
-    options = { amount: 400, currency: 'AUD', description: 'Pay day', recipient: recipient['token'] }
-    transfer_token = Pin::Transfer.create(options)['token']
-    expect(Pin::Transfer.line_items(transfer_token).first).to include('amount', 'created_at', 'currency', 'type')
+    expect(Pin::Transfer.line_items(transfer['token']).first)
+      .to include('amount', 'created_at', 'currency', 'type')
   end
 
   it 'creates a transfer for a recipient, given a transfer hash' do
-    options ={ email: 'hello3@example.com', name: 'Roland Robot', bank_account: { name: 'Roland Robot', bsb: '123456', number: 987654321 } }
-    recipient = Pin::Recipient.create(options)
-
-    transfer = { amount: 400, currency: 'AUD', description: 'Pay day', recipient: recipient['token'] }
-    expect(Pin::Transfer.create(transfer)['token']).to match(/^[a-z]{4}[_]/)
+    expect(transfer['token']).to match(/^[a-z]{4}[_]/)
   end
 
   it 'returns a paginated list of all transfers' do
@@ -27,12 +38,7 @@ describe Pin::Transfer, :vcr do
   end
 
   it 'returns the details of a transfer' do
-    options ={ email: 'hello@example.com', name: 'Roland Robot', bank_account: { name: 'Roland Robot', bsb: '123456', number: 987654321 } }
-    recipient = Pin::Recipient.create(options)
-
-    options = { amount: 400, currency: 'AUD', description: 'Pay day', recipient: recipient['token'] }
-    transfer_token = Pin::Transfer.create(options)['token']
-    expect(Pin::Transfer.find(transfer_token)['token']).to eq transfer_token
+    expect(Pin::Transfer.find(transfer['token'])['token']).to eq transfer['token']
   end
 
   it 'should not show a charge if end_date is out of range' do

--- a/spec/webhook_endpoints_spec.rb
+++ b/spec/webhook_endpoints_spec.rb
@@ -1,47 +1,36 @@
 require 'spec_helper'
 
 RSpec.describe 'WebhookEndpoints', :vcr, class: Pin::WebhookEndpoints do
+  let(:token) {
+    Pin::WebhookEndpoints.create({ url: "http://example.com/webhooks#{Time.now.to_i}/" })['token']
+  }
+
   before(:each) do
     Pin::Base.new(ENV['PIN_SECRET'], :test)
   end
 
   it 'should create a webhook endpoint and returns its details' do
-    options = { url: "http://example.com/webhooks#{Time.now.to_i}/" }
-    token = Pin::WebhookEndpoints.create(options)['token']
     expect(token).to match(/^whe_/)
     Pin::WebhookEndpoints.delete(token) # since we are only allowed 5 or so sandbox webhooks
   end
 
   it 'should list webhook endpoints' do
-    options = { url: "http://example.com/webhooks#{Time.now.to_i}/" }
-    token = Pin::WebhookEndpoints.create(options)['token']
     expect(Pin::WebhookEndpoints.all).to_not eq []
     Pin::WebhookEndpoints.delete(token) # since we are only allowed 5 or so sandbox webhooks
   end
 
   it 'should list webhook endpoint on a page given a page' do
     request = Pin::WebhookEndpoints.all(1, true)
-    options = { url: "http://example.com/webhooks#{Time.now.to_i}/" }
-    token = Pin::WebhookEndpoints.create(options)['token']
-
     expect(request[:response]).to_not eq []
-
     Pin::WebhookEndpoints.delete(token) # since we are only allowed 5 or so sandbox webhooks
   end
 
   it 'should show a webhook endpoint given a token' do
-    options = { url: "http://example.com/webhooks#{Time.now.to_i}/" }
-    token = Pin::WebhookEndpoints.create(options)['token']
-
     expect(Pin::WebhookEndpoints.find(token)['token']).to eq token
-
     Pin::WebhookEndpoints.delete(token) # since we are only allowed 5 or so sandbox webhooks
   end
 
   it 'should delete a webhook endpoint given a token' do
-    options = { url: "http://example.com/webhooks_delete#{Time.now.to_i}/" }
-    token = Pin::WebhookEndpoints.create(options)['token']
-
     expect(Pin::WebhookEndpoints.delete(token).response.code).to eq "204"
   end
 end


### PR DESCRIPTION
***Commented out test working in this PR

I ran into a little stumbling block regarding the tests.
I wanted to add to pin_up and first that meant getting the tests working. However, I did find that updating the VCR cassettes using my Secret Pin Payment Pin broke a lot of tests because my Pin Payment data is different to pin_up's Pin Payment test data.

I would like to make the tests very easy to update (i.e updating VCR cassettes), easy to extend tests for future features and easy for new contributors to add to this project.

To overcome this issue, I fixed all the tests so that they are data independent. This would enable all contributors to create VCR cassettes that will enable all tests to work off the bat! I also updated the documentation.

I squashed all my commits into a single commit. If you would rather the individual commits then I can PR that branch. If you have any comments let me know :)