### PR TITLE
Plan-Wrap Pin Payments Plan API, test & update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ An optional second parameter can be passed in to set the environment (:live or :
 
 An optional third parameter can be passed in to set the timeout of HTTParty in seconds. The default is `1800` (30 minutes).
 
-### Charges
+## Charges
 ##### List All Charges
     Pin::Charges.all
 
@@ -58,7 +58,7 @@ With Pagination:
     # request[:response] => response hash
     # request[:pagination] => "pagination":{"current":3,"previous":2,"next":4,"per_page":25,"pages":10,"count":239}
 
-See https://pin.net.au/docs/api/charges#search-charges for a full list of options.
+See [Pin Payments Charges API](https://pinpayments.com/developers/api-reference/charges#search-charges) for a full list of options.
 
 ##### Create A Charge
     charge = {email: "email@example.com", description: "Description", amount: "400", currency: "AUD", ip_address: "127.0.0.1", customer_token: "cus_token"   }
@@ -75,7 +75,7 @@ Also known as a pre-auth, this will hold a charge to be captured by for up to 5 
 ##### Capture an authorised charge
     Pin::Charges.capture(charge)
 
-### Customers
+## Customers
 ##### List All Customers
     Pin::Customer.all
 
@@ -112,19 +112,17 @@ With Pagination:
 
 ##### Update A Customer
 ###### Update Card details
----
+
     Pin::Customer.update('cus_token', hash_of_details)
 
 If passing a hash of details, it must be the full list of details of the credit card to be stored. (https://pin.net.au/docs/api/customers#put-customer)
 
 ###### Update only an email
----
 
     hash_of_details = {email: 'new_email@example.com'}
     Pin::Customer.update('cus_token', hash_of_details)
 
 ###### Update card by token
----
 
     hash_of_details = {card_token: 'new_card_token'}
     Pin::Customer.update('cus_token', hash_of_details)
@@ -186,8 +184,52 @@ This will list all refunds for a particular charge (will return an empty hash if
 
 Will return a card_token that can be stored against a customer.
 
-Only use this method if you're comfortable sending card details to your server - otherwise you can use a form that Pin provides (https://pin.net.au/docs/guides/payment-forms) and get the card_token that way.
+Only use this method if you're comfortable sending card details to your server - otherwise you can use a form that Pin provides (https://pinpayments.com/developers/integration-guides/payment-forms) and get the card_token that way.
 
+## Plans
+##### Create A Plan
+    Pin::Plan.create(plan)
+
+    plan = { name: 'Coffee Plan', 
+             amount: '1000', 
+             currency: 'AUD', 
+             interval: 30, 
+             interval_unit: 'day', 
+             setup_amount: 0, 
+             trial_amount: 0, 
+             trial_interval: 7, 
+             trial_interval_unit: 'day' }
+
+    Pin::Plan.create(plan)
+    
+##### List All Plans
+    Pin::Plan.all
+
+Show Plans on a particular page:
+
+    Pin::Plan.all(3)
+
+With Pagination:
+
+    Pin::Plan.all(3,true)
+    
+##### Find a Plan
+
+    Pin::Plan.find(plan_token)
+
+    Return the details of a specified plan
+    
+##### Update a Plan
+    Update the name of a specified plan. Only the plan name can be updated!
+    
+    Pin::Plan.update(plan_token, name_hash)
+    
+    name_hash = { name: 'new_plan_name' }
+
+##### Delete a Plan
+    Deletes a plan and all of its subscriptions. You will not be able to recover this. Plans can only be deleted if they have no running subscriptions.
+    
+    Pin::Plan.delete(plan_token)
 
 ## Recipients
 The recipients API allows you to post bank account details and retrieve a token that you can safely store in your app. You can send funds to recipients using the [transfers API].
@@ -237,7 +279,7 @@ With Pagination:
     # request[:response] => response hash
     # request[:pagination] => "pagination":{"current":3,"previous":2,"next":4,"per_page":25,"pages":10,"count":239}
 
-See https://pin.net.au/docs/api/transfers#search-transfers for a full list of options.
+See [Pin Payments Transfers API](https://pinpayments.com/developers/api-reference/transfers#search-transfers) for a full list of options.
 
 ##### Get the line items associated with transfer.
 `Pin::Transfer.line_items(transfer_token)`
@@ -291,7 +333,7 @@ The requested resource could not be found in Pin.
 A number of parameters sent to Pin were invalid.
 
 ### ChargeError
-Something went wrong while creating a charge in Pin. This could be due to insufficient funds, a card being declined or expired. A full list of possible errors is available [here](https://pin.net.au/docs/api/charges).
+Something went wrong while creating a charge in Pin. This could be due to insufficient funds, a card being declined or expired. A full list of possible errors is available [here](https://pinpayments.com/developers/api-reference/charges).
 
 ### InsufficientPinBalance
 

--- a/lib/pin_up.rb
+++ b/lib/pin_up.rb
@@ -13,5 +13,6 @@ require 'pin_up/recipient'
 require 'pin_up/refund'
 require 'pin_up/transfer'
 require 'pin_up/webhook_endpoints'
+require 'pin_up/plan'
 
 require 'pin_up/pin_errors'

--- a/lib/pin_up/plan.rb
+++ b/lib/pin_up/plan.rb
@@ -1,0 +1,79 @@
+module Pin
+  ##
+  # This class models Pins Plans API
+  class Plan < Base
+    ##
+    # Lists all plans for your account
+    # args: page (Fixnum), pagination (Boolean)
+    # returns: a collection of customer objects
+    #
+    # if pagination is passed, access the response hash with [:response]
+    # and the pagination hash with [:pagination]
+    #
+    # https://www.pinpayments.com/developers/api-reference/plans
+    def self.all(page = nil, pagination = false)
+      build_collection_response(make_request(:get, {url: "plans?page=#{page}" } ), pagination)
+    end
+
+    ##
+    # Create a plan given plan details
+    # args: options (Hash)
+    # returns: a plan object
+    # https://www.pinpayments.com/developers/api-reference/plans
+    def self.create(options = {})
+      build_response(make_request(:post, { url: 'plans', options: options }))
+    end
+
+    ##
+    # Find a plan for your account given a token
+    # args: token (String)
+    # returns: a plan object
+    # https://www.pinpayments.com/developers/api-reference/plans#get-plan
+    def self.find(token)
+      build_response(make_request(:get, {url: "plans/#{token}" } ))
+    end
+
+    ##
+    # Update a plan given a token
+    # args: token (String), options (Hash)
+    # returns: a plan object
+    # https://www.pinpayments.com/developers/api-reference/plans#put-plan
+    def self.update(token, options = {})
+      build_response(make_request(:put, { url: "plans/#{token}", options: options }))
+    end
+
+    ##
+    # Delete a plan given a token
+    # args: token (String)
+    # returns: nil
+    # https://www.pinpayments.com/developers/api-reference/plans#delete-plan
+    def self.delete(token)
+      build_response(make_request(:delete, { url: "plans/#{token}" } ))
+    end
+
+    ##
+    # List Subscriptions associated with a plan given a token
+    # args: token (String)
+    # returns: nil
+    # 
+    def self.subscriptions(token, page = nil, pagination = false)
+      build_collection_response(make_request(:get, { url: "plans/#{token}/subscriptions" } ), pagination)
+    end
+
+    ##
+    # Create a subscription for a plan given a customer_token OR a card_token
+    # args: customer_token (String), card (String) see docs.
+    # returns: a subscription object
+    #
+    def self.create_subscription(token, customer_token, card_token = nil)
+      options = if card_token
+                  { customer_token: customer_token,
+                    card_token: card_token}
+                else
+                  { customer_token: customer_token }
+                end
+
+      build_response(make_request(:post, {url: "plans/#{token}/subscriptions", options: options} ))
+    end
+  end
+end

--- a/spec/plan_spec.rb
+++ b/spec/plan_spec.rb
@@ -1,0 +1,134 @@
+require 'spec_helper'
+
+describe 'Plan', :vcr, class: Pin::Plan do
+  let(:time) { Time.now.iso8601(4) }
+  let(:plan) {
+    { name: "Plan#{time}",
+      amount: '1000',
+      currency: 'AUD',
+      interval: 30,
+      interval_unit: 'day',
+      setup_amount: 0,
+      trial_amount: 0,
+      trial_interval: 7,
+      trial_interval_unit: 'day' }
+  }
+
+  let(:plan_2) {
+    { name: "Subscription#{time}",
+     amount: '1000',
+     currency: 'AUD',
+     interval: 1,
+     interval_unit: 'day',
+     setup_amount: 27900,
+     trial_amount: 0,
+     trial_interval: '',
+     trial_interval_unit: '' }
+  }
+
+  let(:plan_2_token) {
+    Pin::Plan.create(plan_2)['token']
+  }
+
+  let(:plan_token) {
+    Pin::Plan.create(plan)['token']
+  }
+
+  let(:card_1) {
+    { number: '5520000000000000',
+     expiry_month: '12',
+     expiry_year: '2025',
+     cvc: '123',
+     name: 'Roland Robot',
+     address_line1: '123 Fake Street',
+     address_city: 'Melbourne',
+     address_postcode: '1234',
+     address_state: 'Vic',
+     address_country: 'Australia' }
+  }
+
+  let(:card_2) {
+    { number: '4200000000000000',
+     expiry_month: '12',
+     expiry_year: '2020',
+     cvc: '111',
+     name: 'Roland TestRobot',
+     address_line1: '123 Fake Road',
+     address_line2: '',
+     address_city: 'Melbourne',
+     address_postcode: '1223',
+     address_state: 'Vic',
+     address_country: 'AU' }
+  }
+
+  let(:customer) {
+    Pin::Customer.create('email@example.com', card_1)
+  }
+
+  let(:customer_token) {
+    customer['token']
+  }
+
+  let(:card_2_token) {
+    Pin::Card.create(card_2)['token']
+  }
+
+  let(:link_card_2_to_customer) {
+    Pin::Customer.create_card(customer_token, card_2_token)
+  }
+
+  before(:each) do
+    Pin::Base.new(ENV['PIN_SECRET'], :test)
+  end
+
+  it 'should create a new plan and return its details' do
+    expect(Pin::Plan.create(plan))
+      .to match a_hash_including("name"=>match(/(Plan)/),
+                                 "token"=>match(/(plan)[_]([\w-]{22})/),
+                                 "amount"=>1000,
+                                 "currency"=>"AUD",
+                                 "setup_amount"=>0,
+                                 "trial_amount"=>0,
+                                 "interval"=>30,
+                                 "interval_unit"=>"day",
+                                 "trial_interval"=>7,
+                                 "trial_interval_unit"=>"day",
+                                 "expiration_interval"=>0,
+                                 "expiration_interval_unit"=>"",
+                                 "active_subscriptions"=>0,
+                                 "trial_subscriptions"=>0)
+  end
+
+  it 'should return a paginated list of all plans' do
+    expect(Pin::Plan.all).to_not eq []
+  end
+
+  it 'should go to a specific page when page paramater is passed' do
+    request = Pin::Plan.all(2, true)
+    expect(request[:pagination]['current']).to eq 2
+  end
+
+  it 'should list customers on a page given a page' do
+    request = Pin::Plan.all(1, true)
+    expect(request[:response]).to_not eq []
+  end
+
+  it 'should return pagination if true is passed for pagination' do
+    request = Pin::Plan.all(1, true)
+    request[:pagination].key?(%W('current previous next per_page pages count))
+  end
+
+  it 'should return the details of a specified plan given a token' do
+    expect(Pin::Plan.find(plan_token)['token']).to eq(plan_token)
+  end
+
+  it 'should update the name of a specified plan given a token' do
+    expect(Pin::Plan.update(plan_token, { name: "Updated" })['name'])
+      .to eq("Updated")
+    Pin::Plan.delete(plan_token) # Cleanup as Plan names must be unique
+  end
+
+  it 'should delete a plan with zero subscriptions given a token' do
+    expect(Pin::Plan.delete(plan_token).code).to eq 204
+  end
+end


### PR DESCRIPTION
This PR adds Plan API functionality to pin_up. 

I did omit the following:
POST /plans/plan-token/subscriptions
GET /plans/plan-token/subscriptions

The reason for this is I wanted to decouple this PR from the subscription PR. The above two API routes will be added to the subscription PR along with their associated tests. I did leave the skeletons for two tests to cover this functionality in the errors_spec. Again these will be added in the next PR, subscriptions.

Looking forward to your comments :)

Andre