### PR TITLE
Subscription-Wrap API, test & update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,8 @@ Only use this method if you're comfortable sending card details to your server -
              trial_amount: 0, 
              trial_interval: 7, 
              trial_interval_unit: 'day' }
+             
+Note: setup_amount, trial_amount, trial_interval and trial_interval_unit are all optional fields. 
 
     Pin::Plan.create(plan)
     
@@ -220,16 +222,77 @@ With Pagination:
     Return the details of a specified plan
     
 ##### Update a Plan
-    Update the name of a specified plan. Only the plan name can be updated!
+Update the name of a specified plan. Only the plan name can be updated!
     
     Pin::Plan.update(plan_token, name_hash)
     
     name_hash = { name: 'new_plan_name' }
 
 ##### Delete a Plan
-    Deletes a plan and all of its subscriptions. You will not be able to recover this. Plans can only be deleted if they have no running subscriptions.
+Deletes a plan and all of its subscriptions. You will not be able to recover this. 
+
+Note: Plans can only be deleted if they have no running subscriptions.
     
     Pin::Plan.delete(plan_token)
+
+## Subscriptions
+##### Create A Subscription
+Activate a new subscription and return its details. The customer's card will immeadiately be billed the initial plan amount, unless there's a trial period. 
+
+
+    subscription =     { plan_token: plan_token,
+                         customer_token: customer_token,
+                         card_token: card_token,
+                         include_setup_fee: true }
+
+Note: card_token and include_setup_fee are both optional.
+
+    Pin::Subscription.create(subscription)
+    
+##### List All Subscriptions
+
+    Pin::Subscription.all
+
+Show Subscriptions on a particular page:
+
+    Pin::Subscription.all(3)
+
+With Pagination:
+
+    Pin::Subscription.all(3,true)
+    
+##### Find a Subscription
+Return the details of a subscription.
+
+    Pin::Subscription.find(subscription_token)
+    
+##### Update a Subscription
+Updates the card associated with a subscription identified by the subscription token.
+    
+Note: The card token must already be associated to the customer of the subscription.
+    
+    Pin::Subscription.update(subscription_token, card_token)
+    
+##### Delete a Subscription
+Cancels the subscription identified by the subscription token. Subscriptions can only be cancelled if they are in a trial or active state. 
+
+Note: Subscriptions will only attain a cancelled state once the subscription period has elapsed. Until such time subscriptions will be in a state of 'Cancelling'.
+    
+    Pin::Subscription.delete(plan_token)
+    
+##### Reactivate a Subscription
+Reactivates the subscription identified by the subscription token returning the details of the subscription
+    
+    Pin::Subscription.reactivate(plan_token)
+
+##### List Subscription history
+Fetch the ledger entries relating to a subscription identified by a subscription token
+    
+    Pin::Subscription.history(subscription_token)
+
+###### With pagination
+
+    Pin::Subscription.history(subscription_token, 3, true)
 
 ## Recipients
 The recipients API allows you to post bank account details and retrieve a token that you can safely store in your app. You can send funds to recipients using the [transfers API].

--- a/lib/pin_up.rb
+++ b/lib/pin_up.rb
@@ -14,5 +14,6 @@ require 'pin_up/refund'
 require 'pin_up/transfer'
 require 'pin_up/webhook_endpoints'
 require 'pin_up/plan'
+require 'pin_up/subscription'
 
 require 'pin_up/pin_errors'

--- a/lib/pin_up/pin_errors.rb
+++ b/lib/pin_up/pin_errors.rb
@@ -18,6 +18,12 @@ module Pin
         case response['error']
         when 'cannot_delete_primary_card'
           raise Pin::InvalidResource.new(response, response['error_description'])
+        when 'invalid_card'
+          raise Pin::InvalidResource.new(response, response['error_description'])
+        when 'invalid_state'
+          raise Pin::InvalidResource.new(response, response['error_description'])
+        when 'invalid_request'
+          raise Pin::InvalidResource.new(response, response['error_description'])
         else
           raise Pin::ChargeError.new(response)
         end

--- a/lib/pin_up/subscription.rb
+++ b/lib/pin_up/subscription.rb
@@ -1,0 +1,80 @@
+module Pin
+  ##
+  # This class models Pins Subscription API
+  class Subscription < Base
+    ##
+    # Lists all subscriptions for your account
+    # args: page (Fixnum), pagination (Boolean)
+    # returns: a collection of subscription objects
+    #
+    # if pagination is passed, access the response hash with [:response]
+    # and the pagination hash with [:pagination]
+    #
+    # https://www.pinpayments.com/developers/api-reference/subscriptions#get-subscriptions
+    def self.all(page = nil, pagination = false)
+      build_collection_response(make_request(:get, { url: "subscriptions?page=#{page}" }), pagination)
+    end
+
+    ##
+    # Create a subscription given subscription details
+    # args: options (Hash)
+    # returns: a subscription object
+    # https://www.pinpayments.com/developers/api-reference/subscriptions#post-subscriptions
+    def self.create(options = {})
+      build_response(make_request(:post, { url: 'subscriptions', options: options }))
+    end
+
+    ##
+    # Find a subscription for your account given a token
+    # args: token (String)
+    # returns: a subscription object
+    # https://www.pinpayments.com/developers/api-reference/subscriptions#get-subscription
+    def self.find(token)
+      build_response(make_request(:get, { url: "subscriptions/#{token}" }))
+    end
+
+    ##
+    # Update a subscription for your account given a token
+    # and any of: email, card (hash),card_token
+    # args: token (String), options (Hash)
+    # returns: a subscription object
+    # https://pin.net.au/docs/api/subscriptions#put-subscription
+    # NB: When providing a card (hash), you need to specify
+    # the full list of details.
+    def self.update(token, card_token = nil)
+      options = unless card_token.empty?
+                  { card_token: card_token }
+                else
+                  card_token
+                end
+      build_response(make_request(:put, { url: "subscriptions/#{token}", options: options }))
+    end
+
+    ##
+    # Delete (cancel) a subscription given a token
+    # args: token (String)
+    # returns: nil
+    # https://www.pinpayments.com/developers/api-reference/subscriptions#delete-subscription
+    def self.delete(token)
+      build_response(make_request(:delete, { url: "subscriptions/#{token}" }))
+    end
+
+    ##
+    # Reactivate a subscription given a token
+    # args: token (String)
+    # returns: nil
+    # https://www.pinpayments.com/developers/api-reference/subscriptions#reactivate-subscription
+    def self.reactivate(token)
+      build_response(make_request(:put, { url: "subscriptions/#{token}/reactivate" }))
+    end
+
+    ##
+    # Fetch all History for a subscription given a token
+    # args: token (String)
+    # returns: nil
+    # https://www.pinpayments.com/developers/api-reference/subscriptions#history-subscription
+    def self.history(token, page = nil, pagination = false)
+      build_collection_response(make_request(:get, { url: "subscriptions/#{token}/history?page=#{page}" }), pagination)
+    end
+  end
+end

--- a/spec/customers_spec.rb
+++ b/spec/customers_spec.rb
@@ -102,7 +102,6 @@ describe 'Customer', :vcr, class: Pin::Customer do
   end
 
   it 'should create a card given customer token and card hash' do
-    # card = { publishable_api_key: ENV['PUBLISHABLE_SECRET'], number: '5520000000000000', expiry_month: '12', expiry_year: '2018', cvc: '123', name: 'Roland TestRobot', address_line1: '123 Fake Road', address_line2: '', address_city: 'Melbourne', address_postcode: '1223', address_state: 'Vic', address_country: 'AU' }
     expect(Pin::Customer.create_card(customer_token, card_1)['token']).to match(/(card)[_]([\w-]{22})/)
   end
 

--- a/spec/errors_spec.rb
+++ b/spec/errors_spec.rb
@@ -14,6 +14,24 @@ describe 'Errors', :vcr, class: Pin::PinError do
       address_country: 'Australia' }
   }
 
+  let(:card_2) {
+    { number: '4200000000000000',
+     expiry_month: '12',
+     expiry_year: '2020',
+     cvc: '111',
+     name: 'Roland TestRobot',
+     address_line1: '123 Fake Road',
+     address_line2: '',
+     address_city: 'Melbourne',
+     address_postcode: '1223',
+     address_state: 'Vic',
+     address_country: 'AU' }
+  }
+
+  let(:card_2_token) {
+    Pin::Card.create(card_2)['token']
+  }
+
   let(:customer_token) {
     Pin::Customer.create('email@example.com', card_1)['token']
   }
@@ -85,7 +103,17 @@ describe 'Errors', :vcr, class: Pin::PinError do
   let(:plan_token) {
     Pin::Plan.create(plan)['token']
   }
-  
+
+  let(:subscription_1) {
+    { plan_token: plan_token,
+      customer_token: customer_token,
+      include_setup_fee: false }
+  }
+
+  let(:subscription_1_token) {
+    Pin::Subscription.create(subscription_1)['token']
+  }
+
   before(:each) do
     Pin::Base.new(ENV['PIN_SECRET'], :test)
   end
@@ -198,7 +226,7 @@ describe 'Errors', :vcr, class: Pin::PinError do
   it 'should raise a 404 error when trying to find a plan token that does not exist' do
     expect { Pin::Plan.find('invalid_plan_token') }.to raise_error do |error|
       expect(error).to be_a Pin::ResourceNotFound
-      expect(error.message).to eq 'No resource was found at this URL.'
+      expect(error.message).to eq 'The requested resource could not be found.'
       expect(error.response).to be_a Hash
     end
   end
@@ -206,7 +234,7 @@ describe 'Errors', :vcr, class: Pin::PinError do
   it 'should raise a 404 error when updating a plan token that does not exist' do
     expect { Pin::Plan.update('invalid_plan_token', { name: 'new_plan_name' }) }.to raise_error do |error|
       expect(error).to be_a Pin::ResourceNotFound
-      expect(error.message).to eq 'No resource was found at this URL.'
+      expect(error.message).to eq 'The requested resource could not be found.'
       expect(error.response).to be_a Hash
     end
   end
@@ -225,14 +253,101 @@ describe 'Errors', :vcr, class: Pin::PinError do
   it 'should raise a 404 not found when deleting a plan token that does not exist' do
     expect { Pin::Plan.delete('invalid_plan_token') }.to raise_error do |error|
       expect(error).to be_a Pin::ResourceNotFound
-      expect(error.message).to eq 'No resource was found at this URL.'
+      expect(error.message).to eq 'The requested resource could not be found.'
       expect(error.response).to be_a Hash
     end
   end
 
-  it 'should raise a 404 not found when creating a new subscription on a plan token that does not exist' do
+  it 'should raise a 404 not found when creating a new subscription on an invalid plan token' do
+    expect { Pin::Plan.create_subscription('invalid_plan_token', customer_token) }.to raise_error do |error|
+      expect(error).to be_a Pin::ResourceNotFound
+      expect(error.message).to eq 'The requested resource could not be found.'
+      expect(error.response).to be_a Hash
+    end
   end
 
   it 'should raise a 404 not found when returning a list of subscriptions for a plan token that does not exist' do
+    expect { Pin::Plan.subscriptions('invalid_plan_token') }.to raise_error do |error|
+      expect(error).to be_a Pin::ResourceNotFound
+      expect(error.message).to eq 'The requested resource could not be found.'
+      expect(error.response).to be_a Hash
+    end
+  end
+
+  ###
+  # Subscription Errors
+  ###
+  it 'should raise a 400 when creating a subscription token & any field validation fails' do
+    subscription_w_no_plan_token = subscription_1.tap { |h| h[:plan_token] = '' }
+    expect { Pin::Subscription.create(subscription_w_no_plan_token) }.to raise_error do |error|
+      expect(error).to be_a Pin::InvalidResource
+      expect(error.response['messages'][0]).to match a_hash_including("message"=>"Plan must exist")
+    end
+  end
+
+  it 'should raise a 404 error when trying to create a subscription with an invalid plan token' do
+    subscription_w_invalid_plan_token = subscription_1.tap { |h| h[:plan_token] = 'invalid_token' }
+    expect { Pin::Subscription.create(subscription_w_invalid_plan_token) }.to raise_error do |error|
+      expect(error).to be_a Pin::ResourceNotFound
+      expect(error.message).to eq 'The requested resource could not be found.'
+      expect(error.response).to be_a Hash
+    end
+  end
+
+  it 'should raise a 404 error when searching for an invalid subscription token' do
+    expect { Pin::Subscription.find('invalid_plan_token') }.to raise_error do |error|
+      expect(error).to be_a Pin::ResourceNotFound
+      expect(error.message).to eq 'The requested resource could not be found.'
+      expect(error.response).to be_a Hash
+    end
+  end
+
+  it 'should raise a 400 when updating a subscription & no card token is supplied' do
+    expect { Pin::Subscription.update(subscription_1_token, '') }.to raise_error do |error|
+      expect(error).to be_a Pin::InvalidResource
+      expect(error.response['messages'][0]).to match a_hash_including("message"=>"Card token must be present")
+      expect(error.response).to be_a Hash
+    end
+  end
+
+  it 'should raise a 400 error when update a subscription with an invalid card token' do
+    expect { Pin::Subscription.update(subscription_1_token, 'invalid_card_token') }.to raise_error do |error|
+      expect(error).to be_a Pin::InvalidResource
+      expect(error.message).to eq("Invalid card token")
+      expect(error.response).to be_a Hash
+    end
+  end
+
+  it 'should raise a 404 when updating a subscription with invalid token' do
+    expect { Pin::Subscription.update('invalid_subscription_token', card_2_token) }.to raise_error do |error|
+      expect(error).to be_a Pin::ResourceNotFound
+      expect(error.message).to eq 'The requested resource could not be found.'
+      expect(error.response).to be_a Hash
+    end
+  end
+
+  it 'should raise a 404 not found when deleting an invalid subscription token' do
+    expect { Pin::Subscription.delete('invalid_subscription_token') }.to raise_error do |error|
+      expect(error).to be_a Pin::ResourceNotFound
+      expect(error.message).to eq 'The requested resource could not be found.'
+      expect(error.response).to be_a Hash
+    end
+  end
+
+  it 'should raise a 400 invalid state when deleting a cancelled subscription' do
+    deleted_subscription_token = Pin::Subscription.delete(subscription_1_token)['token']
+    expect { Pin::Subscription.delete(deleted_subscription_token) }.to raise_error do |error|
+      expect(error).to be_a Pin::InvalidResource
+      expect(error.message).to eq 'Cannot cancel subscription when state is trial_cancelling'
+      expect(error.response).to be_a Hash
+    end
+  end
+
+  it 'should raise a 404 when reactivating a subscription with invalid token' do
+    expect { Pin::Subscription.reactivate('invalid_subscription_token') }.to raise_error do |error|
+      expect(error).to be_a Pin::ResourceNotFound
+      expect(error.message).to eq 'The requested resource could not be found.'
+      expect(error.response).to be_a Hash
+    end
   end
 end

--- a/spec/plan_spec.rb
+++ b/spec/plan_spec.rb
@@ -77,6 +77,26 @@ describe 'Plan', :vcr, class: Pin::Plan do
     Pin::Customer.create_card(customer_token, card_2_token)
   }
 
+  let(:subscription) {
+    { plan_token: plan_token,
+      customer_token: customer_token,
+      include_setup_fee: false }
+  }
+
+  let(:subscription_token) {
+    Pin::Subscription.create(subscription)['token']
+  }
+
+  let(:subscription_2) {
+    { plan_token: plan_2_token,
+     customer_token: customer_token,
+     include_setup_fee: false }
+  }
+
+  let(:subscription_2_token) {
+    Pin::Subscription.create(subscription_2)['token']
+  }
+
   before(:each) do
     Pin::Base.new(ENV['PIN_SECRET'], :test)
   end
@@ -130,5 +150,40 @@ describe 'Plan', :vcr, class: Pin::Plan do
 
   it 'should delete a plan with zero subscriptions given a token' do
     expect(Pin::Plan.delete(plan_token).code).to eq 204
+  end
+
+  it 'should delete a plan and all de-activated subscriptions' do
+    subscription_2_token # attach a subscription to the plan
+    Pin::Subscription.delete(subscription_2_token) # deactivate subscription
+    expect(Pin::Plan.delete(plan_token).code).to eq 204
+  end
+
+  it 'should create a new subscription to the specified plan' do
+    plan = { object: Pin::Plan.create_subscription(plan_token, customer_token),
+             created_at: Time.now }
+    expect(plan[:object])
+      .to match a_hash_including("state"=>"trial",
+                                 "token"=>match(/(sub)[_]([\w-]{22})/),
+                                 "plan_token"=>"#{plan_token}",
+                                 "customer_token"=>"#{customer_token}",
+                                 "card_token"=> nil)
+  end
+
+  it 'should create new plan & linked subscription using a new credit card (billing card_2)' do
+    link_card_2_to_customer
+    expect(Pin::Plan.create_subscription(plan_2_token, customer_token, card_2_token))
+      .to match a_hash_including("state"=>"active",
+                                 "token"=>match(/(sub)[_]([\w-]{22})/),
+                                 "plan_token"=>"#{plan_2_token}",
+                                 "customer_token"=>"#{customer_token}",
+                                 "card_token"=>"#{card_2_token}")
+    charges = Pin::Customer.charges(customer_token)
+    expect(charges[0]['card']['token']).to eq(card_2_token)
+  end
+
+  it 'should return a paginated list of subscriptions for a plan' do
+    subscription_token # attach a subscription to the plan
+    subscription_list = Pin::Plan.subscriptions(plan_token)
+    expect(subscription_list[0]['token']).to eq(subscription_token)
   end
 end

--- a/spec/subscription_spec.rb
+++ b/spec/subscription_spec.rb
@@ -1,0 +1,201 @@
+require 'spec_helper'
+
+describe 'Subscription', :vcr, class: Pin::Subscription do
+  let(:time) { Time.now.iso8601(4) }
+  let(:plan_1) {
+    { name: "Subscription#{time}",
+      amount: '1000',
+      currency: 'AUD',
+      interval: 30,
+      interval_unit: 'day',
+      setup_amount: 0,
+      trial_amount: 0,
+      trial_interval: 7,
+      trial_interval_unit: 'day' }
+  }
+
+  let(:plan_2) {
+    { name: "Subscription#{time}",
+     amount: '1000',
+     currency: 'AUD',
+     interval: 30,
+     interval_unit: 'day',
+     setup_amount: 27900,
+     trial_amount: 0,
+     trial_interval: '',
+     trial_interval_unit: '' }
+  }
+
+  let(:plan_1_token) {
+    Pin::Plan.create(plan_1)['token']
+  }
+
+  let(:plan_2_token) {
+    Pin::Plan.create(plan_2)['token']
+  }
+
+  let(:card_1) {
+    { number: '5520000000000000',
+     expiry_month: '12',
+     expiry_year: '2025',
+     cvc: '123',
+     name: 'Roland Robot',
+     address_line1: '123 Fake Street',
+     address_city: 'Melbourne',
+     address_postcode: '1234',
+     address_state: 'Vic',
+     address_country: 'Australia' }
+  }
+
+  let(:card_2) {
+    { number: '4200000000000000',
+     expiry_month: '12',
+     expiry_year: '2020',
+     cvc: '111',
+     name: 'Roland TestRobot',
+     address_line1: '123 Fake Road',
+     address_line2: '',
+     address_city: 'Melbourne',
+     address_postcode: '1223',
+     address_state: 'Vic',
+     address_country: 'AU' }
+  }
+
+  let(:customer) {
+    Pin::Customer.create('email@example.com', card_1)
+  }
+
+  let(:customer_token) {
+    customer['token']
+  }
+
+  let(:card_2_token) {
+    Pin::Card.create(card_2)['token']
+  }
+
+  let(:link_card_2_to_customer) {
+    Pin::Customer.create_card(customer_token, card_2_token)
+  }
+
+  let(:subscription_1) {
+    { plan_token: plan_1_token,
+      customer_token: customer_token,
+      include_setup_fee: false }
+  }
+
+  let(:subscription_2) {
+    link_card_2_to_customer
+    { plan_token: plan_2_token,
+      customer_token: customer_token,
+      card_token: card_2_token,
+      include_setup_fee: true }
+  }
+
+  let(:subscription_1_token) {
+    Pin::Subscription.create(subscription_1)['token']
+  }
+
+  let(:subscription_2_token) {
+    Pin::Subscription.create(subscription_2)['token']
+  }
+
+  before(:each) do
+    Pin::Base.new(ENV['PIN_SECRET'], :test)
+  end
+
+  it 'should create a new subscription billing default card and return its details' do
+    expect(Pin::Subscription.create(subscription_1))
+      .to match a_hash_including("state"=>"trial",
+                                 "cancelled_at"=>nil,
+                                 "token"=>match(/(sub)[_]([\w-]{22})/),
+                                 "plan_token"=>"#{plan_1_token}",
+                                 "customer_token"=>"#{customer_token}",
+                                 "card_token"=> nil)
+  end
+
+  it 'should create a new subscription billing card_2' do
+    expect(Pin::Subscription.create(subscription_2))
+      .to match a_hash_including("state"=>"active",
+                                 "token"=>match(/(sub)[_]([\w-]{22})/),
+                                 "plan_token"=>"#{plan_2_token}",
+                                 "customer_token"=>"#{customer_token}",
+                                 "card_token"=>"#{card_2_token}")
+    charges = Pin::Customer.charges(customer_token)
+    expect(charges[0]['card']['token']).to eq(card_2_token)
+  end
+
+  it 'should create a new subscription with setup fee, charge equals amount + setup fee' do
+    Pin::Subscription.create(subscription_2)
+    charges = Pin::Customer.charges(customer_token)
+    expect(charges[0]['amount'].to_i).to eq (plan_2[:setup_amount].to_i + plan_2[:amount].to_i)
+  end
+
+  it 'should list all subscriptions' do
+    expect(Pin::Subscription.all).to_not eq []
+  end
+
+  it 'should go to a specific page when page paramater is passed' do
+    request = Pin::Subscription.all(20, true)
+    expect(request[:pagination]['current']).to eq 20
+  end
+
+  it 'should list subscriptions on a page given a page' do
+    request = Pin::Subscription.all(1, true)
+    expect(request[:response]).to_not eq []
+  end
+
+  it 'should return pagination if true is passed for pagination' do
+    request = Pin::Subscription.all(1, true)
+    request[:pagination].keys.include?(%W('current previous next per_page pages count))
+  end
+
+  it 'should not list subscriptions for a given page if there are no subscriptions' do
+    request = Pin::Subscription.all(25, true)
+    expect(request[:response]).to eq []
+  end
+
+  it 'should show a subscription given a token' do
+    expect(Pin::Subscription.find(subscription_2_token)['token']).to eq(subscription_2_token)
+  end
+
+  it 'should update the subscription charged card given a subscription & card token' do
+    Pin::Customer.create_card(customer_token, card_2_token) # register card to customer
+    sub = Pin::Subscription.update(subscription_1_token, card_2_token)
+    expect(sub['card_token']).to eq card_2_token
+    primary_customer_card_token = customer['card']['token']
+    expect(primary_customer_card_token).to_not eq card_2_token
+  end
+
+  it 'should delete(deactivate) a subscription given a token' do
+    expect(Pin::Subscription.delete(subscription_2_token)['state']).to eq('cancelling')
+  end
+
+  it 'should reactivate the subscription given a token' do
+    deactivated = Pin::Subscription.delete(subscription_2_token)
+    expect(Pin::Subscription.reactivate(deactivated['token'])['state']).to eq('active')
+  end
+
+  it 'should fetch history for a subscription given a token' do
+    expect(Pin::Subscription.history(subscription_2_token)).to_not eq []
+  end
+
+  it 'should go to a specific page when page parameter is passed' do
+    request = Pin::Subscription.history(subscription_2_token, 20, true)
+    expect(request[:pagination]['current']).to eq 20
+  end
+
+  it 'should list subscriptions on a page given a page' do
+    request = Pin::Subscription.history(subscription_2_token, 1, true)
+    expect(request[:response]).to_not eq []
+  end
+
+  it 'should return pagination if true is passed for pagination' do
+    request = Pin::Subscription.history(subscription_2_token, 1, true)
+    request[:pagination].key?(%W('current previous next per_page pages count))
+  end
+
+  it 'should not list subscriptions for a given page if there are no subscriptions' do
+    request = Pin::Subscription.history(subscription_2_token, 25, true)
+    expect(request[:response]).to eq []
+  end
+end


### PR DESCRIPTION
This PR adds Subscription API functionality to pin_up.

It also adds 
POST /plans/plan-token/subscriptions
GET /plans/plan-token/subscriptions

Documentation has been updated, as well as the error response.
I emailed Pin Payments and highlighted inconsistency in their errors response for plan & subscription APIs. Since the Plan pull request Pin Payments updated this, hence the change to the expected error message response for the Plan API.

If you have any suggestion for improvements let me know. 

Look forward to your response :)

Andre