### PR TITLE
adding a default case to error handling

### DIFF
--- a/lib/pin_up/pin_errors.rb
+++ b/lib/pin_up/pin_errors.rb
@@ -36,6 +36,8 @@ module Pin
       when 422
         message = handle_bad_response(response)
         raise Pin::InvalidResource.new(response, message)
+      else
+        raise Pin::Unknown.new(response, "Unknown error with status code #{http_status}")
       end
     end
 
@@ -70,6 +72,9 @@ module Pin
     def to_s
       @message
     end
+  end
+
+  class Unknown < SimpleError
   end
 
   class Unauthorized < SimpleError


### PR DESCRIPTION
When a response has an error, if we don't have a default case, we may end up with 'nil' response from `build_response`.
lib/pin_up/base.rb:47

For example, if http_status code was 408 or 500.

